### PR TITLE
test(contract): fix missing vitest globals imports

### DIFF
--- a/server/tests/contract/nisabYearRecords.get.test.ts
+++ b/server/tests/contract/nisabYearRecords.get.test.ts
@@ -1,4 +1,4 @@
-import { vi, type Mock } from 'vitest';
+import { vi, type Mock, describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
 /**
  * Contract Test: GET /api/nisab-year-records
  * 

--- a/server/tests/contract/nisabYearRecords.put.test.ts
+++ b/server/tests/contract/nisabYearRecords.put.test.ts
@@ -1,4 +1,4 @@
-import { vi, type Mock } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi, type Mock } from 'vitest';
 /**
  * Contract Test: PUT /api/nisab-year-records/:id
  * 

--- a/tests/contract/payment-records.contract.test.ts
+++ b/tests/contract/payment-records.contract.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import request from 'supertest';
 import app from '../../server/src/app';
 


### PR DESCRIPTION
## What

Contract tests in server/tests/contract/ failed at runtime with  because they used vitest globals without explicit imports.

## Changes

- : Add  imports from vitest
- : Add missing  imports
- : Add vitest imports

All 445 server tests pass.