### PR TITLE
chore(deps): bump nodemailer 8→9

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -34,7 +34,7 @@
         "morgan": "^1.10.1",
         "node-cron": "^4.2.1",
         "node-fetch": "^2.7.0",
-        "nodemailer": "^8.0.7",
+        "nodemailer": "^9.0.1",
         "redis": "^4.6.13",
         "resend": "^6.4.2",
         "tsconfig-paths": "^4.2.0",
@@ -5338,9 +5338,9 @@
       }
     },
     "node_modules/nodemailer": {
-      "version": "8.0.7",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.7.tgz",
-      "integrity": "sha512-pkjE4mkBzQjdJT4/UmlKl3pX0rC9fZmjh7c6C9o7lv66Ac6w9WCnzPzhbPNxwZAzlF4mdq4CSWB5+FbK6FWCow==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.3.tgz",
+      "integrity": "sha512-n+YP+NKwR5zRWa60k3GiQ6Q3B4KXCoAw40dAKeCtYn020iNN74aWK2liXIC3ZEATeGql7we3tE3t8QwhY0eskw==",
       "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"

--- a/server/package.json
+++ b/server/package.json
@@ -47,7 +47,7 @@
     "morgan": "^1.10.1",
     "node-cron": "^4.2.1",
     "node-fetch": "^2.7.0",
-    "nodemailer": "^8.0.7",
+    "nodemailer": "^9.0.1",
     "redis": "^4.6.13",
     "resend": "^6.4.2",
     "tsconfig-paths": "^4.2.0",


### PR DESCRIPTION
Bumps nodemailer from ^8.0.7 to ^9.0.1 in server.

Supersedes Dependabot PR #305 (which was failing CI due to the old broken workflow).

Note: vitest 4.x bump was attempted but has breaking changes in mock constructor patterns (14 test files affected). That will be handled in a separate dedicated migration.