### PR TITLE
fix: currency consistency across app (#310)

### DIFF
--- a/client/src/components/assets/AssetForm.tsx
+++ b/client/src/components/assets/AssetForm.tsx
@@ -33,6 +33,7 @@ import {
   getPropertyGuidance,
   getModifierBadge
 } from '../../utils/assetModifiers';
+import { getSupportedCurrencies, getCurrencySymbol, type CurrencyCode } from '../../utils/formatters';
 import { RetirementTreatmentSection } from './form-sections/RetirementTreatmentSection';
 import { PassiveInvestmentSection } from './form-sections/PassiveInvestmentSection';
 import { RestrictedAccountSection } from './form-sections/RestrictedAccountSection';
@@ -491,14 +492,9 @@ export const AssetForm: React.FC<AssetFormProps> = ({ asset, onSuccess, onCancel
               aria-invalid={!!errors.currency}
               aria-describedby={errors.currency ? 'currency-error' : 'currency-help'}
             >
-              <option value="USD">USD - US Dollar</option>
-              <option value="EUR">EUR - Euro</option>
-              <option value="GBP">GBP - British Pound</option>
-              <option value="SAR">SAR - Saudi Riyal</option>
-              <option value="AED">AED - UAE Dirham</option>
-              <option value="PKR">PKR - Pakistani Rupee</option>
-              <option value="INR">INR - Indian Rupee</option>
-              <option value="MYR">MYR - Malaysian Ringgit</option>
+              {getSupportedCurrencies().map((code: CurrencyCode) => (
+                <option key={code} value={code}>{code} - {getCurrencySymbol(code)}</option>
+              ))}
             </select>
             <p id="currency-help" className="mt-1 text-xs text-gray-500">
               Select the currency for this asset's value

--- a/client/src/components/liabilities/LiabilityForm.tsx
+++ b/client/src/components/liabilities/LiabilityForm.tsx
@@ -22,6 +22,7 @@ import { Liability } from '../../types';
 import { Button, Input } from '../ui';
 import { EncryptedBadge } from '../ui/EncryptedBadge';
 import { calculateDeductibleLiabilities } from '../../core/calculations/wealthCalculator';
+import { getSupportedCurrencies, getCurrencySymbol, type CurrencyCode } from '../../utils/formatters';
 
 interface LiabilityFormProps {
     liability?: Liability;
@@ -185,11 +186,9 @@ export const LiabilityForm: React.FC<LiabilityFormProps> = ({ liability, onSucce
                             onChange={e => handleChange('currency', e.target.value)}
                             className="w-full border-gray-300 rounded-md shadow-sm focus:border-primary-500 focus:ring-primary-500"
                         >
-                            <option value="USD">USD</option>
-                            <option value="EUR">EUR</option>
-                            <option value="GBP">GBP</option>
-                            <option value="SAR">SAR</option>
-                            <option value="PKR">PKR</option>
+                            {getSupportedCurrencies().map((code: CurrencyCode) => (
+                                <option key={code} value={code}>{code} - {getCurrencySymbol(code)}</option>
+                            ))}
                         </select>
                     </div>
                 </div>


### PR DESCRIPTION
Fixes #310

Problem: User could select IDR in settings, but the asset and liability forms had hardcoded currency lists missing IDR, TRY, EGP (and in liability form: also AED, INR, MYR).

Fix: Replaced hardcoded option lists in AssetForm.tsx and LiabilityForm.tsx with dynamic getSupportedCurrencies() from formatters.ts. All 11 supported currencies now appear in every dropdown.

Verification: Client TypeScript clean, build passes, 424 tests pass.