### PR TITLE
fix: wire AnnualSummary payment statistics (#314)

### DIFF
--- a/server/src/__tests__/unit/AnnualSummaryService.test.ts
+++ b/server/src/__tests__/unit/AnnualSummaryService.test.ts
@@ -72,9 +72,9 @@ describe('AnnualSummaryService', () => {
     };
 
     const mockPayments = [
-      { id: 'pay1', amount: 1000, recipientCategory: 'fakir', recipientType: 'individual' },
-      { id: 'pay2', amount: 1500, recipientCategory: 'miskin', recipientType: 'individual' },
-      { id: 'pay3', amount: 750, recipientCategory: 'fakir', recipientType: 'organization' }
+      { id: 'pay1', amount: 1000, recipientCategory: 'fakir', recipientType: 'individual', recipientName: 'Ahmad' },
+      { id: 'pay2', amount: 1500, recipientCategory: 'miskin', recipientType: 'individual', recipientName: 'Bilal' },
+      { id: 'pay3', amount: 750, recipientCategory: 'fakir', recipientType: 'organization', recipientName: 'Ahmad' }
     ];
 
     beforeEach(() => {
@@ -230,6 +230,98 @@ describe('AnnualSummaryService', () => {
 
       expect(analysis.wealthChangePercent).toBe(0);
       expect(analysis.zakatChangePercent).toBe(0);
+    });
+
+    it('should calculate unique recipients correctly', async () => {
+      await service.generateSummary(mockSnapshotId, mockUserId);
+
+      const call = (AnnualSummaryModel.createOrUpdate as Mock).mock.calls[0][1];
+      const recipientSummary = call.recipientSummary;
+
+      // 2 unique recipient names: 'Ahmad' (pay1+pay3) and 'Bilal' (pay2)
+      expect(recipientSummary.uniqueRecipients).toBe(2);
+    });
+
+    it('should calculate average payment correctly', async () => {
+      await service.generateSummary(mockSnapshotId, mockUserId);
+
+      const call = (AnnualSummaryModel.createOrUpdate as Mock).mock.calls[0][1];
+      const recipientSummary = call.recipientSummary;
+
+      // totalPaid = 3250, numberOfPayments = 3, average = 3250/3 ≈ 1083.33
+      expect(recipientSummary.averagePayment).toBeCloseTo(1083.33, 1);
+    });
+
+    it('should calculate paid amounts in comparative analysis', async () => {
+      const previousSnapshot = {
+        id: 'prev-snapshot',
+        userId: mockUserId,
+        gregorianYear: 2023,
+        totalWealth: 120000,
+        zakatAmount: 3000
+      };
+      const previousPayments = [
+        { id: 'prev-pay1', amount: 2000, recipientCategory: 'fakir', recipientType: 'individual', recipientName: 'Ahmad' }
+      ];
+
+      (YearlySnapshotModel.findPrimaryByYear as Mock).mockResolvedValue(previousSnapshot);
+      // First call returns current payments, second call returns previous year payments
+      (PaymentRecordModel.findBySnapshot as Mock)
+        .mockResolvedValueOnce(mockPayments)
+        .mockResolvedValueOnce(previousPayments);
+
+      await service.generateSummary(mockSnapshotId, mockUserId);
+
+      const call = (AnnualSummaryModel.createOrUpdate as Mock).mock.calls[0][1];
+      expect(call.comparativeAnalysis).toBeDefined();
+      expect(call.comparativeAnalysis.previousYear.paid).toBe(2000);
+      expect(call.comparativeAnalysis.currentYear.paid).toBe(3250);
+    });
+
+    it('should determine payment consistency as improved when significantly higher', async () => {
+      const previousSnapshot = {
+        id: 'prev-snapshot',
+        userId: mockUserId,
+        gregorianYear: 2023,
+        totalWealth: 120000,
+        zakatAmount: 3000
+      };
+      const previousPayments = [
+        { id: 'prev-pay1', amount: 500, recipientCategory: 'fakir', recipientType: 'individual', recipientName: 'Ahmad' }
+      ];
+
+      (YearlySnapshotModel.findPrimaryByYear as Mock).mockResolvedValue(previousSnapshot);
+      (PaymentRecordModel.findBySnapshot as Mock)
+        .mockResolvedValueOnce(mockPayments)  // current: 3250
+        .mockResolvedValueOnce(previousPayments); // previous: 500, ratio = 6.5 > 1.2
+
+      await service.generateSummary(mockSnapshotId, mockUserId);
+
+      const call = (AnnualSummaryModel.createOrUpdate as Mock).mock.calls[0][1];
+      expect(call.comparativeAnalysis.changes.paymentConsistency).toBe('improved');
+    });
+
+    it('should determine payment consistency as declined when no payments current year', async () => {
+      const previousSnapshot = {
+        id: 'prev-snapshot',
+        userId: mockUserId,
+        gregorianYear: 2023,
+        totalWealth: 120000,
+        zakatAmount: 3000
+      };
+      const previousPayments = [
+        { id: 'prev-pay1', amount: 1000, recipientCategory: 'fakir', recipientType: 'individual', recipientName: 'Ahmad' }
+      ];
+
+      (YearlySnapshotModel.findPrimaryByYear as Mock).mockResolvedValue(previousSnapshot);
+      (PaymentRecordModel.findBySnapshot as Mock)
+        .mockResolvedValueOnce([])  // no current year payments
+        .mockResolvedValueOnce(previousPayments);
+
+      await service.generateSummary(mockSnapshotId, mockUserId);
+
+      const call = (AnnualSummaryModel.createOrUpdate as Mock).mock.calls[0][1];
+      expect(call.comparativeAnalysis.changes.paymentConsistency).toBe('declined');
     });
 
     it('should not include comparative analysis for first year', async () => {

--- a/server/src/services/AnnualSummaryService.ts
+++ b/server/src/services/AnnualSummaryService.ts
@@ -151,13 +151,39 @@ export class AnnualSummaryService {
         count: stats.count,
         totalAmount: stats.totalAmount
       })),
-      uniqueRecipients: 0, // TODO(#314): Implement proper unique recipient counting
-      averagePayment: 0 // TODO(#314): Implement proper average calculation
+      uniqueRecipients: new Set(payments.map(p => p.recipientName).filter(Boolean)).size,
+      averagePayment: payments.length > 0 ? totalPaid / payments.length : 0
     };
 
     // Get previous year's snapshot for comparison
     const previousYear = snapshot.gregorianYear - 1;
     const previousSnapshot = await YearlySnapshotModel.findPrimaryByYear(userId, previousYear);
+
+    // Query previous year payments for comparison
+    let previousYearPaid = 0;
+    let previousPaymentCount = 0;
+    if (previousSnapshot) {
+      const previousPayments = await PaymentRecordModel.findBySnapshot(previousSnapshot.id, userId);
+      previousPaymentCount = previousPayments.length;
+      previousYearPaid = previousPayments.reduce((sum, p) => sum + p.amount, 0);
+    }
+
+    // Determine payment consistency
+    let paymentConsistency: 'improved' | 'maintained' | 'declined' = 'maintained';
+    if (previousSnapshot) {
+      if (payments.length === 0 && previousPaymentCount > 0) {
+        paymentConsistency = 'declined';
+      } else if (payments.length > 0 && previousPaymentCount === 0) {
+        paymentConsistency = 'improved';
+      } else if (payments.length > 0 && previousPaymentCount > 0 && previousYearPaid > 0) {
+        const changeRatio = totalPaid / previousYearPaid;
+        if (changeRatio > 1.2) {
+          paymentConsistency = 'improved';
+        } else if (changeRatio < 0.8) {
+          paymentConsistency = 'declined';
+        }
+      }
+    }
 
     let comparativeAnalysis: ComparativeAnalysis | undefined = undefined;
     if (previousSnapshot) {
@@ -169,13 +195,13 @@ export class AnnualSummaryService {
           year: previousYear,
           wealth: previousSnapshot.totalWealth,
           zakat: previousSnapshot.zakatAmount,
-          paid: 0 // TODO(#314): Get actual paid amount from payments
+          paid: previousYearPaid
         },
         currentYear: {
           year: snapshot.gregorianYear,
           wealth: snapshot.totalWealth,
           zakat: snapshot.zakatAmount,
-          paid: 0 // TODO(#314): Get actual paid amount from payments
+          paid: totalPaid
         },
         changes: {
           wealthChange: wealthChange,
@@ -186,7 +212,7 @@ export class AnnualSummaryService {
           zakatChangePercent: previousSnapshot.zakatAmount > 0
             ? (zakatChange / previousSnapshot.zakatAmount) * 100
             : 0,
-          paymentConsistency: 'maintained' as const // TODO(#314): Calculate based on actual payments
+          paymentConsistency: paymentConsistency as any
         }
       };
     }


### PR DESCRIPTION
Fixes #314

Replaces hardcoded zeros with actual payment data:
- uniqueRecipients: count of distinct recipient names
- averagePayment: totalPaid / numberOfPayments (handles div by zero)
- comparativeAnalysis.paid: queries actual payments for current and previous year
- paymentConsistency: improved/maintained/declined based on year-over-year payment ratio (1.2x threshold)

Added 5 new tests covering all new behavior. Total: 450 tests passing.