### PR TITLE
feat(auth): durable session invalidation across restarts (#312)

### DIFF
--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -222,6 +222,24 @@ router.post('/login',
 
       const refreshToken = jwtService.createRefreshToken(user.id);
 
+      // Persist the session (#312): durable revocation anchor
+      try {
+        await getPrismaClient().userSession.create({
+          data: {
+            userId: user.id,
+            accessToken,
+            refreshToken,
+            ipAddress: req.ip || null,
+            userAgent: (req.headers['user-agent'] as string) || null,
+            issuedAt: new Date(),
+            expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+            isActive: true
+          }
+        });
+      } catch (sessionErr) {
+        logger.error('Failed to persist session on login (non-fatal):', sessionErr);
+      }
+
       // Decrypt profile data
       let profileData = {};
       if (user.profile) {
@@ -410,6 +428,24 @@ router.post('/register',
       });
 
       const refreshToken = jwtService.createRefreshToken(user.id);
+
+      // Persist the session (#312)
+      try {
+        await getPrismaClient().userSession.create({
+          data: {
+            userId: user.id,
+            accessToken,
+            refreshToken,
+            ipAddress: req.ip || null,
+            userAgent: (req.headers['user-agent'] as string) || null,
+            issuedAt: new Date(),
+            expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+            isActive: true
+          }
+        });
+      } catch (sessionErr) {
+        logger.error('Failed to persist session on register (non-fatal):', sessionErr);
+      }
 
       // Decrypt profile data
       if (user.profile) {
@@ -646,6 +682,24 @@ router.post('/refresh',
         return;
       }
 
+      // Durable session check (#312): if the session backing this refresh token
+      // was terminated (logout, password change, admin revocation), refuse refresh.
+      // This survives server restarts, unlike the in-memory revocation set.
+      const session = await getPrismaClient().userSession.findFirst({
+        where: { refreshToken, userId: decoded.userId }
+      });
+
+      if (session && !session.isActive) {
+        res.status(401).json({
+          success: false,
+          error: {
+            code: 'SESSION_REVOKED',
+            message: 'Session has been revoked'
+          }
+        });
+        return;
+      }
+
       // Generate new tokens
       const newAccessToken = jwtService.createAccessToken({
         userId: user.id,
@@ -654,6 +708,23 @@ router.post('/refresh',
       });
 
       const newRefreshToken = jwtService.createRefreshToken(user.id);
+
+      // Rotation: persist new tokens on the session row so revocation keeps
+      // tracking the CURRENT refresh token; retire the old value.
+      if (session) {
+        try {
+          await getPrismaClient().userSession.update({
+            where: { id: session.id },
+            data: {
+              accessToken: newAccessToken,
+              refreshToken: newRefreshToken,
+              refreshedAt: new Date()
+            }
+          });
+        } catch (sessionErr) {
+          logger.error('Failed to update session on refresh (non-fatal):', sessionErr);
+        }
+      }
 
       // Only revoke the old refresh token after successful generation of new tokens
       // Implement token rotation: each refresh token can only be used once
@@ -723,16 +794,32 @@ router.post('/logout',
   authenticate,
   asyncHandler(async (req: AuthenticatedRequest, res: ExpressResponse) => {
     try {
-      // In a production environment, you would:
-      // 1. Add the access token to a blacklist
-      // 2. Remove refresh tokens from database
-      // 3. Clear any user sessions
+      // Durable revocation (#312): terminate the session row(s) matching this
+      // user + access token so the refresh flow rejects post-logout token use,
+      // even after a server restart.
+      const authHeader = req.headers.authorization || '';
+      const accessToken = authHeader.replace(/^Bearer\s+/i, '');
 
-      // For now, we'll just acknowledge the logout
+      const result = await getPrismaClient().userSession.updateMany({
+        where: {
+          userId: req.userId,
+          accessToken: accessToken
+        },
+        data: {
+          isActive: false,
+          terminatedAt: new Date(),
+          terminationReason: 'logout'
+        }
+      });
+
+      // Also revoke the in-memory access-token blacklist (immediate effect)
+      revokeToken(accessToken);
+
       res.status(200).json({
         success: true,
         data: {
-          message: 'Logged out successfully'
+          message: 'Logged out successfully',
+          sessionsTerminated: result.count
         },
         metadata: {
           timestamp: new Date().toISOString(),
@@ -740,6 +827,7 @@ router.post('/logout',
         }
       });
     } catch (error) {
+      logger.error('Logout error:', error);
       res.status(500).json({
         success: false,
         error: {

--- a/server/tests/integration/sessionInvalidation.test.ts
+++ b/server/tests/integration/sessionInvalidation.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Integration Test: Durable session invalidation (#312)
+ *
+ * Contracts:
+ *   - Login/register persist an active UserSession row carrying the tokens
+ *   - Logout terminates the session (isActive=false, reason='logout')
+ *   - /auth/refresh rejects a refresh token whose session is terminated
+ *     — the check reads the DB, so revocation survives a server restart
+ *   - Token rotation updates the session row to hold the CURRENT tokens
+ */
+import request from 'supertest';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import app from '../../src/app';
+import { PrismaClient } from '@prisma/client';
+
+const EMAIL_A = `sess-a-${Date.now()}@example.com`;
+const EMAIL_B = `sess-b-${Date.now()}@example.com`;
+const PASSWORD = 'Password1!';
+
+describe('Integration: Durable session invalidation (#312)', () => {
+  const prisma = new PrismaClient();
+  let userAId = '';
+  let userBId = '';
+
+  beforeAll(async () => {
+    for (const email of [EMAIL_A, EMAIL_B]) {
+      const reg = await request(app).post('/api/auth/register').send({
+        email,
+        password: PASSWORD,
+        confirmPassword: PASSWORD,
+        firstName: 'Sess',
+        lastName: 'Tester',
+      });
+      if (reg.status !== 201) {
+        throw new Error(`Registration failed: ${JSON.stringify(reg.body)}`);
+      }
+      if (reg.body.data.user.email === EMAIL_A) {
+        userAId = reg.body.data.user.id;
+      } else {
+        userBId = reg.body.data.user.id;
+      }
+    }
+  });
+
+  afterAll(async () => {
+    await prisma.userSession.deleteMany({ where: { userId: { in: [userAId, userBId] } } }).catch(() => {});
+    await prisma.user.deleteMany({ where: { id: { in: [userAId, userBId] } } }).catch(() => {});
+    await prisma.$disconnect();
+  });
+
+  it('login persists an active session row carrying the tokens', async () => {
+    const login = await request(app).post('/api/auth/login').send({
+      email: EMAIL_A,
+      password: PASSWORD,
+    });
+    expect(login.status).toBe(200);
+
+    const sessions = await prisma.userSession.findMany({
+      where: { userId: userAId }
+    });
+    expect(sessions.length).toBeGreaterThanOrEqual(1);
+    const latest = sessions[sessions.length - 1];
+    expect(latest.isActive).toBe(true);
+    expect(latest.refreshToken).toBeTruthy();
+  });
+
+  it('logout terminates the sessionDurably; refresh with revoked token fails', async () => {
+    const login = await request(app).post('/api/auth/login').send({
+      email: EMAIL_A,
+      password: PASSWORD,
+    });
+    expect(login.status).toBe(200);
+    const { accessToken, refreshToken } = login.body.data.tokens;
+
+    let row = await prisma.userSession.findFirst({ where: { refreshToken } });
+    expect(row).not.toBeNull();
+    expect(row!.isActive).toBe(true);
+
+    const logout = await request(app)
+      .post('/api/auth/logout')
+      .set('Authorization', `Bearer ${accessToken}`);
+    expect(logout.status).toBe(200);
+    expect(logout.body.data.sessionsTerminated).toBeGreaterThanOrEqual(1);
+
+    // Durably terminated in DB
+    row = await prisma.userSession.findFirst({ where: { refreshToken } });
+    expect(row!.isActive).toBe(false);
+    expect(row!.terminationReason).toBe('logout');
+
+    // Refresh with the terminated session's refresh token → 401
+    const refresh = await request(app)
+      .post('/api/auth/refresh')
+      .send({ refreshToken });
+    expect(refresh.status).toBe(401);
+  });
+
+  it('refresh rotates tokens and updates the session row', async () => {
+    const login = await request(app).post('/api/auth/login').send({
+      email: EMAIL_B,
+      password: PASSWORD,
+    });
+    expect(login.status).toBe(200);
+    const oldRefresh = login.body.data.tokens.refreshToken;
+
+    const session = await prisma.userSession.findFirst({
+      where: { userId: userBId, refreshToken: oldRefresh }
+    });
+    expect(session).not.toBeNull();
+
+    const refresh = await request(app)
+      .post('/api/auth/refresh')
+      .send({ refreshToken: oldRefresh });
+    expect(refresh.status).toBe(200);
+    expect(refresh.body.data.tokens.refreshToken).not.toBe(oldRefresh);
+
+    // Session row tracks the rotated tokens
+    const updated = await prisma.userSession.findUnique({
+      where: { id: session!.id }
+    });
+    expect(updated!.refreshToken).toBe(refresh.body.data.tokens.refreshToken);
+    expect(updated!.refreshedAt).not.toBeNull();
+
+    // The OLD refresh token must now be rejected (rotation + revocation)
+    const reuseOld = await request(app)
+      .post('/api/auth/refresh')
+      .send({ refreshToken: oldRefresh });
+    expect(reuseOld.status).toBe(401);
+  });
+});


### PR DESCRIPTION
## Summary

Session/token revocation was previously **in-memory only** — a server restart wiped all logout/revocation state, and the logout endpoint was an acknowledged no-op stub. Issue #312 makes session revocation durable via the existing-but-unused `UserSession` Prisma model.

### Changes
- **Login + register** now persist a `UserSession` row (access/refresh tokens, IP, user-agent, 7d expiry). Persistence failure is logged non-fatally so auth never breaks on a DB hiccup.
- **`POST /auth/refresh`** now consults the session row: if the session was terminated, the refresh is rejected with 401 `SESSION_REVOKED` — durable across restarts, unlike the in-memory revocation set that was the root gap.
- **Token rotation** updates the session row so revocation always tracks the *current* refresh token.
- **`POST /logout`** (previously a no-op stub) now terminates the matching session row (`terminationReason='logout'`, `terminatedAt` set) and returns `sessionsTerminated` count.
- Scope note: the check runs on the **refresh path only**, keeping the hot path (every authenticated API call) DB-free; access tokens remain 15-min TTL, so revocation takes effect within ≤15 min for access tokens and immediately for refresh.

### Tests (3 new integration, all passing locally)
- Login persists an active session row carrying the tokens
- Logout terminates durably (DB assertion: `isActive=false`, `terminationReason='logout'`) and refresh with the revoked token is rejected
- Rotation updates the session row to the new tokens; old refresh token then rejected

### Verification
- `npx tsc --noEmit` clean; full server suite **461/461 passing** locally

Closes #312

Refs: docs/plans/2026-08-31-muharram-1448-v0.13.0-release-plan.md (Stream B)