### PR TITLE
docs: Hijri moon-cycle release cadence + v0.13.0 release plan

### DIFF
--- a/docs/plans/2026-08-31-muharram-1448-v0.13.0-release-plan.md
+++ b/docs/plans/2026-08-31-muharram-1448-v0.13.0-release-plan.md
@@ -1,0 +1,100 @@
+# ZakApp v0.13.0 "Muharram 1448 Stabilization" Release Plan
+
+> **For Hermes:** Use subagent-driven-development skill to implement this plan task-by-task. Main is protected — every stream is a PR. Green CI is a hard gate.
+
+**Goal:** Stabilize ZakApp (github.com/slimatic/zakapp, live at zakapp.org), harden data retention across upgrades, close security gaps, clean the codebase, and establish a Hijri moon-cycle release cadence.
+
+**Architecture:** Express + Prisma + SQLite server, Vite + React + RxDB (offline-first PWA) client, CouchDB sync, Docker Compose on Umbrel behind Caddy. AGPL-3.0-or-later.
+
+## Baseline Audit (2026-08-31, verified live)
+
+**Healthy — keep as-is:**
+- Server: 450/450 tests pass (43 files). Client: 445 passed, 15 skipped (49 files).
+- CI: test.yml + security-scan.yml correctly split; 6 disabled workflows are inert.
+- All licenses AGPL-3.0-or-later, consistent.
+- 15 Prisma migrations; destructive ops only in 4 (3 are ADD COLUMN only — need re-verify during Stream A).
+- Version 0.12.0 across all 5 packages.
+
+**Needs work:**
+| # | Finding | Severity |
+|---|---|---|
+| 1 | `docker/entrypoint.sh:62` — `npx prisma migrate deploy \|\| npx prisma db push --accept-data-loss` — **data-loss bomb**, silently reshapes prod DB | P0 |
+| 2 | `scripts/ops/docker-compose-migrate.sh --force-push` same bomb, opt-in but dangerous | P1 |
+| 3 | #311: password reset uses `Math.random()`, in-memory Map instead of Prisma `PasswordReset` model; `// TODO(#311)` in AuthController | P1 |
+| 4 | #312: session blocklists are in-memory; lost on restart | P1 |
+| 5 | #320: 80 server + 88 client unused imports/locals (tsc --noUnusedLocals) | P2 |
+| 6 | #321: vitest 4 migration not started (28 files) | P2 |
+| 7 | Env file sprawl: 8 .env template variants in root | P3 |
+| 8 | 3 committed artifacts (`.bak` ×2, `test-results/.last-run.json`) | P3 |
+| 9 | Stale local branches (5 merged-gone), stale copilot/dependabot remotes | P3 |
+| 10 | docs/ has MIGRATION.md + MIGRATION_GUIDE.md duplicates; untriaged TODO count = 17 | P3 |
+
+---
+
+## Stream A — Data Safety (P0, first)
+
+**A1.** `docker/entrypoint.sh:62` — remove `|| npx prisma db push --accept-data-loss` fallback. Migration failure must **fail container startup loudly**, never silently reshape prod.db.
+```bash
+# Before
+npx prisma migrate deploy 2>/dev/null || npx prisma db push --accept-data-loss
+# After
+npx prisma migrate deploy || { echo "FATAL: migration failed — refusing to start with potential data loss" >&2; exit 1; }
+```
+
+**A2.** Verify compose volume mount target == `DATABASE_URL` path (the 2026-07-12 incident). Add a CI/doctor script that asserts this.
+
+**A3.** Pre-deploy backup script: `scripts/ops/backup-before-upgrade.sh` (tar volume + config before any `docker compose up -d`).
+
+**A4.** Upgrade-path test: seed old-schema SQLite DB, run `migrate deploy`, assert all rows intact. Add to CI as `migration-safety.yml` job or extend test.yml.
+
+**A5.** Re-verify the 4 destructive migrations are non-destructive in practice (RedefineTables column-list fragility documented in skill).
+
+## Stream B — Security Quick Wins (P1)
+
+**B1 → Issue #311:** Wire `AuthController.requestPasswordReset` to existing `EmailService.sendPasswordResetEmail()`; replace `Math.random()` with `crypto.randomBytes(32).toString('hex')`; switch from in-memory Map to Prisma `PasswordReset` model (model already exists); TTL + single-use checks; tests.
+
+**B2 → Issue #312:** Wire `UserSession` Prisma model into auth; persist refresh-token blocklist; check in auth middleware; tests.
+
+## Stream C — Code Health (P2)
+
+**C1 → Issue #320:** Unused imports — **eslint --fix only** (regex previously broke multiline imports). Verify with `tsc --noEmit --noUnusedLocals` → 0. One PR for server, one for client.
+
+**C2:** Resolve/document the 17 remaining TODOs; delete stale ones.
+
+## Stream D — Test Hardening (P2, dedicated)
+
+**D1 → Issue #321:** Vitest 4 migration, standalone PR per skill guidance (class-based mocks, 28 files).
+**D2:** 15 skipped client tests — fix or document with issue refs. No silent skips.
+
+## Stream E — UX Polish (gstack-vetted)
+
+Audit pass against web-design-guidelines + html-deliverable-qa: skip-to-content, focus indicators, mobile nav aria-expanded, single h1, hardcoded currency sweep (post-#310 regression check), empty alt audit. Visual verification via built dist screenshots, not claims.
+
+## Stream F — Repo Hygiene (P3)
+
+- Archive `docs/` stale files → `docs/archive/` (MIGRATION.md duplication resolves first)
+- Consolidate 8 .env variants → `.env.example` + component examples + one documented template; archive rest to `docs/archive/env/`
+- `git rm` 3 tracked artifacts (.bak ×2, test-results/.last-run.json) + .gitignore
+- Delete 5 merged-gone local branches, copilot/dependabot stale remotes (verify PR state first)
+- 6 `.disabled` workflows: archive to `docs/archive/workflows/` with rationale, keep docker-hub/test/security-scan/yml active
+- deploy-*.sh / *.md doc cross-check: fix references to renamed dirs
+
+## Stream G — Moon-Cycle Release Cadence
+
+- `docs/release-cycle.md`: cadence = 1st of each Hijri month (next: **1 Jumada al-Ula 1448 ≈ 2026-10-12**); PRs merge all cycle, tag at cycle start, moon-sighting ±1 day note (tabular calendar, no religious authority claimed)
+- GitHub Actions release workflow on `v*` tags
+- ROADMAP.md: mark v0.13.0 scope
+
+## Execution Order
+
+A (P0 data safety) → B (security) → C+F (noise reduction before refactors) → D → E → G (cadence docs) → release.
+
+PRs land individually with green CI each time; release tag only after all streams merged.
+
+## Verification (pre-tag gate)
+
+1. `bash ~/.hermes/skills/software-development/zakapp-maintenance/scripts/verify-zakapp-release.sh`
+2. Version parity all 5 package.json
+3. All tests green, 0 skipped-without-reason
+4. Docker: `docker compose up -d` from fresh volume → 200 on all 3 domains → migrate-deploy clean, no data loss on upgrade simulation
+5. No secrets in diffs (GitGuardian gate)

--- a/docs/release-cycle.md
+++ b/docs/release-cycle.md
@@ -1,0 +1,44 @@
+# ZakApp Release Cycle — Hijri Moon-Cycle Cadence
+
+> Adopted 1448-08 (Sha'ban 1448). Releases are cut at the **start of each Hijri month**, aligning the release rhythm with the lunar calendar.
+
+## Cadence
+
+- **One release per Hijri month**, tagged on (or within a day or two of) **1st of the Hijri month**, subject to local moon sighting (+/-1 day tolerance).
+- PRs merge into `main` continuously throughout the month (CI-gated as always).
+- At month start: version bump → CHANGELOG → tag `vX.Y.Z` → Docker Hub build (automated) → deploy to production (Umbrel, with pre-deploy backup).
+
+## Upcoming Cycle Starts
+
+Tabular Islamic calendar (hijridate Umm al-Qura approximation); actual dates may shift ±1 day with moon sighting:
+
+| Hijri month | Approx. Gregorian start | Planned version |
+|---|---|---|
+| Jumada al-Ula 1448 | 2026-10-12 | v0.13.0 — Muharram-cycle stabilization release |
+| Jumada al-Thani 1448 | 2026-11-11 | v0.14.0 |
+| Rajab 1448 | 2026-12-10 | v0.15.0 |
+| Sha'ban 1448 | 2027-01-09 | v0.16.0 |
+
+> v0.13.0 was originally targeted to coincide with 1 Muharram 1448 (June 2026); it slipped and is now releasing in the Jumada al-Ula cycle. Naming convention preserved from the Muharram 1448 audit that started this stabilization effort.
+
+## Per-Cycle Workflow
+
+1. **During the month** — open PRs per workstream; keep `main` green; squash-merge.
+2. **Release PR (last week of the cycle)** — version parity across all 5 `package.json` files, CHANGELOG entry with compare link, ROADMAP check-off.
+3. **Day of release (1st of Hijri month)**:
+   - Merge release PR (CI green gate).
+   - Tag: `git tag -a vX.Y.Z -m "..." && git push origin vX.Y.Z`
+   - Docker Hub workflow builds + pushes on tag.
+   - Deploy: `scripts/ops/backup-before-upgrade.sh` on the server first, then pull new images and `docker compose up -d`.
+   - Verify: 200 on `app.zakapp.org`, `api.zakapp.org/health`, `syncdb.zakapp.org`; migrations container ran `prisma migrate deploy` cleanly.
+4. **Post-release**: close the cycle's milestone, open next cycle's tracking issue.
+
+## Release Naming
+
+Releases are named after the Hijri month they ship in (e.g., "v0.13.0 — Jumada al-Ula 1448")
+
+## Automation
+
+- Docker Hub build/push: `.github/workflows/docker-hub.yml` (on tag `v*` and main pushes)
+- Tests + security scans gate every PR (test.yml, security-scan.yml)
+- A future enhancement: GitHub Action that opens the release PR automatically on the 25th of each Gregorian month (the Hijri month's end varies; lunar math handled by a small script using the tabular calendar)


### PR DESCRIPTION
## Summary

Stream G of the v0.13.0 release plan: adopt a **Hijri moon-cycle release cadence**.

- `docs/release-cycle.md` — one release per Hijri month, tagged at the 1st (±1 day moon sighting), with the full per-cycle workflow (backup → deploy → verify) and upcoming dates: next cycle starts **1 Jumada al-Ula 1448 ≈ 2026-10-12**, the v0.13.0 ship date.
- `docs/plans/2026-08-31-muharram-1448-v0.13.0-release-plan.md` — the audit-derived workstream plan driving this release (Streams A–G).

## Related
- #320 scoping comment: unused-imports sweep deferred to v0.14 (mechanical, needs new eslint plugin; shouldn't gate this release)
- Docs-only change — no runtime behavior affected.