### PR TITLE
feat(ux): dark mode ("Ikhlas Night") — additive, class-strategy, zero light-mode change

### DIFF
--- a/client/src/components/layout/Layout.tsx
+++ b/client/src/components/layout/Layout.tsx
@@ -23,6 +23,7 @@ import { SkipLink } from '../common/SkipLink';
 import { MobileNav } from './MobileNav';
 import { BottomNav } from './BottomNav';
 import { SyncIndicator } from '../SyncIndicator';
+import { ThemeToggle } from './ThemeToggle';
 import { Logo } from '../common/Logo';
 import { Footer } from './Footer';
 
@@ -264,6 +265,9 @@ export const Layout: React.FC<LayoutProps> = ({ children }) => {
             </div>
 
             <div className="flex items-center gap-4">
+              {/* Theme Toggle (light/dark) */}
+              <ThemeToggle />
+
               {/* Sync Status Indicator */}
               <SyncIndicator />
 

--- a/client/src/components/layout/ThemeToggle.tsx
+++ b/client/src/components/layout/ThemeToggle.tsx
@@ -1,0 +1,42 @@
+/**
+ * ThemeToggle — light/dark switch for the header.
+ * Uses the useTheme hook; renders a sun/moon icon button.
+ */
+import React from 'react';
+import { useTheme } from '../../hooks/useTheme';
+
+export const ThemeToggle: React.FC<{ className?: string }> = ({ className = '' }) => {
+  const { isDark, toggleTheme } = useTheme();
+
+  return (
+    <button
+      type="button"
+      onClick={toggleTheme}
+      className={`p-2 rounded-lg text-slate-500 hover:text-slate-700 hover:bg-slate-100 dark:text-slate-400 dark:hover:text-slate-200 dark:hover:bg-slate-800 transition-colors ${className}`}
+      aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
+      title={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
+    >
+      {isDark ? (
+        /* Sun — shown in dark mode, action = go light */
+        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"
+          />
+        </svg>
+      ) : (
+        /* Moon — shown in light mode, action = go dark */
+        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"
+          />
+        </svg>
+      )}
+    </button>
+  );
+};

--- a/client/src/hooks/__tests__/useTheme.test.ts
+++ b/client/src/hooks/__tests__/useTheme.test.ts
@@ -1,0 +1,100 @@
+/**
+ * useTheme — dark-mode state hook (class strategy).
+ *
+ * Persists choice in localStorage ('zakapp-theme'), defaults to system
+ * preference, applies/removes the `dark` class on document.documentElement.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useTheme } from '../useTheme';
+
+describe('useTheme', () => {
+  let matchMediaListeners: Array<(e: { matches: boolean }) => void>;
+
+  beforeEach(() => {
+    matchMediaListeners = [];
+    window.localStorage.clear();
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addEventListener: (_: string, cb: (e: { matches: boolean }) => void) => matchMediaListeners.push(cb),
+        removeEventListener: (_: string, cb: (e: { matches: boolean }) => void) => {
+          matchMediaListeners = matchMediaListeners.filter((l) => l !== cb);
+        },
+      })),
+    });
+  });
+
+  afterEach(() => {
+    document.documentElement.classList.remove('dark');
+  });
+
+  it('defaults to light when no stored theme and system prefers light', () => {
+    const { result } = renderHook(() => useTheme());
+    expect(result.current.theme).toBe('light');
+    expect(result.current.isDark).toBe(false);
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+  });
+
+  it('defaults to dark when system prefers dark and nothing stored', () => {
+    matchMediaListeners = [];
+    // re-mock with matches: true
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: true,
+        media: query,
+        onchange: null,
+        addEventListener: (_: string, cb: (e: { matches: boolean }) => void) => matchMediaListeners.push(cb),
+        removeEventListener: vi.fn(),
+      })),
+    });
+    const { result } = renderHook(() => useTheme());
+    expect(result.current.theme).toBe('dark');
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+
+  it('toggleTheme flips the theme, applies the class, and persists the choice', () => {
+    const { result } = renderHook(() => useTheme());
+    expect(result.current.theme).toBe('light');
+
+    act(() => {
+      result.current.toggleTheme();
+    });
+
+    expect(result.current.theme).toBe('dark');
+    expect(result.current.isDark).toBe(true);
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+    expect(window.localStorage.getItem('zakapp-theme')).toBe('dark');
+
+    act(() => {
+      result.current.toggleTheme();
+    });
+    expect(result.current.theme).toBe('light');
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+    expect(window.localStorage.getItem('zakapp-theme')).toBe('light');
+  });
+
+  it('setTheme persists explicitly and stops following system changes', () => {
+    const { result } = renderHook(() => useTheme());
+    act(() => {
+      result.current.setTheme('dark');
+    });
+    expect(window.localStorage.getItem('zakapp-theme')).toBe('dark');
+
+    // system flips to dark, but user choice wins
+    act(() => {
+      matchMediaListeners.forEach((cb) => cb({ matches: true }));
+    });
+    expect(result.current.theme).toBe('dark');
+
+    // storage failure must not throw
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('quota');
+    });
+    expect(() => result.current.setTheme('light')).not.toThrow();
+  });
+});

--- a/client/src/hooks/useTheme.ts
+++ b/client/src/hooks/useTheme.ts
@@ -1,0 +1,76 @@
+/**
+ * useTheme — dark-mode state hook (class strategy).
+ *
+ * Persists choice in localStorage ('zakapp-theme': 'light' | 'dark' | 'system'),
+ * defaults to system preference, and applies/removes the `dark` class on
+ * document.documentElement. Tailwind is configured with darkMode: 'class'.
+ */
+import { useCallback, useEffect, useState } from 'react';
+
+export type Theme = 'light' | 'dark';
+
+const STORAGE_KEY = 'zakapp-theme';
+
+function readStoredTheme(): Theme | null {
+  try {
+    const v = window.localStorage.getItem(STORAGE_KEY);
+    return v === 'light' || v === 'dark' ? v : null;
+  } catch {
+    return null;
+  }
+}
+
+function systemPrefersDark(): boolean {
+  try {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches;
+  } catch {
+    return false;
+  }
+}
+
+function applyToDocument(theme: Theme): void {
+  const root = document.documentElement;
+  if (theme === 'dark') {
+    root.classList.add('dark');
+  } else {
+    root.classList.remove('dark');
+  }
+}
+
+export function useTheme() {
+  const [theme, setThemeState] = useState<Theme>(() => {
+    return readStoredTheme() ?? (systemPrefersDark() ? 'dark' : 'light');
+  });
+
+  // Keep the DOM in sync (also covers the initial mount).
+  useEffect(() => {
+    applyToDocument(theme);
+  }, [theme]);
+
+  // Follow system changes only while the user hasn't made an explicit choice.
+  useEffect(() => {
+    const mq = window.matchMedia('(prefers-color-scheme: dark)');
+    const onChange = (e: MediaQueryListEvent) => {
+      if (readStoredTheme() === null) {
+        setThemeState(e.matches ? 'dark' : 'light');
+      }
+    };
+    mq.addEventListener('change', onChange);
+    return () => mq.removeEventListener('change', onChange);
+  }, []);
+
+  const setTheme = useCallback((next: Theme) => {
+    try {
+      window.localStorage.setItem(STORAGE_KEY, next);
+    } catch {
+      // private mode / storage disabled — session-only theme is fine
+    }
+    setThemeState(next);
+  }, []);
+
+  const toggleTheme = useCallback(() => {
+    setTheme(theme === 'dark' ? 'light' : 'dark');
+  }, [theme, setTheme]);
+
+  return { theme, setTheme, toggleTheme, isDark: theme === 'dark' };
+}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -37,6 +37,84 @@
 
     --radius: 0.75rem;
   }
+
+  /* ── Dark theme ("Ikhlas Night") — class strategy, additive & non-breaking ── */
+  .dark {
+    --background: 222 47% 7%;
+    /* deep navy-teal, slate-950 family */
+    --foreground: 210 40% 96%;
+
+    --card: 222 44% 11%;
+    --card-foreground: 210 40% 96%;
+
+    --popover: 222 44% 11%;
+    --popover-foreground: 210 40% 96%;
+
+    --primary: 172 66% 50%;
+    /* brighter turquoise for contrast on dark */
+    --primary-foreground: 222 47% 7%;
+
+    --secondary: 45 93% 47%;
+    /* gold, slightly deeper */
+    --secondary-foreground: 222 47% 7%;
+
+    --muted: 217 33% 17%;
+    --muted-foreground: 215 20% 65%;
+
+    --accent: 217 33% 17%;
+    --accent-foreground: 210 40% 96%;
+
+    --destructive: 0 72% 56%;
+    --destructive-foreground: 210 40% 98%;
+
+    --border: 217 27% 22%;
+    --input: 217 27% 22%;
+    --ring: 172 66% 50%;
+  }
+}
+
+/* ── Dark-mode retrofit for hardcoded light utilities ─────────────────────────
+   The app predates dark mode and uses raw slate/white utilities in ~415 places.
+   Rather than touching every component (regression risk), these overrides make
+   the common ones adapt when .dark is on the root. Semantic tokens
+   (bg-card, text-muted-foreground, etc.) remain the preferred going-forward API. */
+.dark {
+  color-scheme: dark;
+}
+.dark body {
+  background-color: hsl(222 47% 7%);
+  color: hsl(210 40% 96%);
+}
+.dark .bg-white { background-color: hsl(var(--card)); }
+.dark .bg-slate-50 { background-color: hsl(217 33% 14%); }
+.dark .bg-slate-100 { background-color: hsl(217 33% 17%); }
+.dark .bg-slate-200 { background-color: hsl(217 27% 22%); }
+.dark .text-slate-900 { color: hsl(210 40% 96%); }
+.dark .text-slate-800 { color: hsl(214 32% 91%); }
+.dark .text-slate-700 { color: hsl(215 25% 83%); }
+.dark .text-slate-600 { color: hsl(215 20% 74%); }
+.dark .text-slate-500 { color: hsl(215 20% 65%); }
+.dark .text-slate-400 { color: hsl(215 16% 55%); }
+.dark .border-slate-200 { border-color: hsl(var(--border)); }
+.dark .border-slate-100 { border-color: hsl(217 27% 18%); }
+.dark .border-slate-300 { border-color: hsl(217 27% 28%); }
+/* Glass panels: dark glass */
+.dark .glass-panel {
+  background-color: hsl(222 44% 11% / 0.8);
+  border-color: hsl(217 27% 22% / 0.5);
+  --tw-ring-color: hsl(0 0% 100% / 0.06);
+}
+.dark .glass-card {
+  background-color: hsl(222 44% 11% / 0.9);
+  border-color: hsl(217 27% 22%);
+}
+.dark .btn-secondary {
+  background-color: hsl(var(--card));
+  border-color: hsl(var(--border));
+  color: hsl(172 66% 50%);
+}
+.dark .btn-secondary:hover {
+  background-color: hsl(217 33% 17%);
 }
 
 @layer components {

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  darkMode: 'class',
   content: [
     "./src/**/*.{js,jsx,ts,tsx}",
   ],
@@ -46,6 +47,26 @@ module.exports = {
         ring: "hsl(var(--ring))",
         background: "hsl(var(--background))",
         foreground: "hsl(var(--foreground))",
+        card: {
+          DEFAULT: "hsl(var(--card))",
+          foreground: "hsl(var(--card-foreground))",
+        },
+        popover: {
+          DEFAULT: "hsl(var(--popover))",
+          foreground: "hsl(var(--popover-foreground))",
+        },
+        muted: {
+          DEFAULT: "hsl(var(--muted))",
+          foreground: "hsl(var(--muted-foreground))",
+        },
+        accent: {
+          DEFAULT: "hsl(var(--accent))",
+          foreground: "hsl(var(--accent-foreground))",
+        },
+        destructive: {
+          DEFAULT: "hsl(var(--destructive))",
+          foreground: "hsl(var(--destructive-foreground))",
+        },
       },
       fontFamily: {
         sans: ['Inter', 'system-ui', 'sans-serif'],


### PR DESCRIPTION
- tailwind: darkMode:'class' + semantic color tokens (card/popover/muted/accent/destructive) mapped to the existing CSS vars
- index.css: full .dark token block (deep navy-teal + brighter turquoise/gold) + retrofit overrides so the ~415 hardcoded slate/white utilities adapt in dark mode without touching component markup
- useTheme hook: localStorage-persisted light/dark, system-preference default, follows OS changes until user chooses
- ThemeToggle (sun/moon, aria-labelled) added to the Layout header
- 4 new hook tests

Verified: client 454 pass/15 skip (baseline + 4), build + PWA precache OK, server untouched (461/461).
