### PR TITLE
feat(ux): Hawl countdown milestones on dashboard ActiveRecordWidget

### DIFF
--- a/client/src/components/dashboard/ActiveRecordWidget.tsx
+++ b/client/src/components/dashboard/ActiveRecordWidget.tsx
@@ -203,6 +203,21 @@ export const ActiveRecordWidget: React.FC<ActiveRecordWidgetProps> = ({ record }
         <p className="text-xs text-gray-500 mt-1">
           {progressPercentage.toFixed(1)}% complete
         </p>
+
+        {/* Hawl countdown milestones — surfaces urgency without any state change */}
+        {daysRemaining <= 30 && daysRemaining > 0 && (
+          <p
+            className="text-xs font-semibold text-amber-600 mt-1"
+            role="status"
+          >
+            ⏳ Zakat due soon — {daysRemaining} day{daysRemaining === 1 ? '' : 's'} left in this Hawl
+          </p>
+        )}
+        {daysRemaining === 0 && (
+          <p className="text-xs font-semibold text-red-600 mt-1" role="status">
+            🔔 Hawl complete — calculate and pay your Zakat now
+          </p>
+        )}
       </div>
 
       {/* Wealth Comparison */}

--- a/client/src/components/dashboard/__tests__/ActiveRecordWidget.countdown.test.tsx
+++ b/client/src/components/dashboard/__tests__/ActiveRecordWidget.countdown.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * Hawl countdown milestones on the ActiveRecordWidget.
+ * Blue-ocean feature: automated Hawl tracking / due-date urgency (competitor gap #4).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { PrivacyProvider } from '../../../contexts/PrivacyContext';
+import { ActiveRecordWidget } from '../ActiveRecordWidget';
+
+vi.mock('../../../hooks/useNisabThreshold', () => ({
+  useNisabThreshold: () => ({ nisabAmount: 5000, isLoading: false }),
+}));
+
+vi.mock('../../../hooks/usePaymentRepository', () => ({
+  usePaymentRepository: () => ({ payments: [], isLoading: false, error: null }),
+}));
+
+vi.mock('react-router-dom', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('react-router-dom')>()),
+  Link: ({ children }: { children: React.ReactNode }) => <a>{children}</a>,
+}));
+
+function daysFromNow(days: number): string {
+  return new Date(Date.now() + days * 24 * 60 * 60 * 1000).toISOString();
+}
+
+function renderWidget(record: Record<string, unknown>) {
+  return render(
+    <PrivacyProvider>
+      <MemoryRouter>
+        <ActiveRecordWidget record={record as never} />
+      </MemoryRouter>
+    </PrivacyProvider>
+  );
+}
+
+const baseRecord = {
+  id: 'r1',
+  startDate: daysFromNow(-354), // default: day 354
+  nisabBasis: 'GOLD',
+  zakatAmount: 100,
+};
+
+describe('ActiveRecordWidget hawl countdown', () => {
+  it('shows the due-soon milestone at 30 days remaining', () => {
+    const { container } = renderWidget({
+      ...baseRecord,
+      startDate: daysFromNow(-324),
+    });
+    const status = container.querySelector('[role="status"]');
+    expect(status?.textContent).toContain('30 days left');
+    expect(status?.textContent).toContain('due soon');
+  });
+
+  it('shows the due-soon milestone at 1 day remaining (singular)', () => {
+    const { container } = renderWidget({
+      ...baseRecord,
+      startDate: daysFromNow(-353),
+    });
+    expect(container.querySelector('[role="status"]')?.textContent).toContain('1 day left');
+  });
+
+  it('shows the Hawl-complete call to action at 0 days remaining', () => {
+    const { container } = renderWidget({
+      ...baseRecord,
+      startDate: daysFromNow(-400),
+    });
+    expect(container.querySelector('[role="status"]')?.textContent).toContain('Hawl complete');
+  });
+
+  it('shows no milestone when the hawl has just started', () => {
+    const { container } = renderWidget({
+      ...baseRecord,
+      startDate: daysFromNow(-10),
+    });
+    expect(container.querySelector('[role="status"]')).toBeNull();
+  });
+});


### PR DESCRIPTION
Blue-ocean quick win from competitive research (gap #4: automated Hawl/due-date
tracking — charity calculators are one-shot, competitors lack anniversary urgency):
- ≤30 days remaining: '⏳ Zakat due soon — N days left' (amber, role=status)
- 0 days remaining: '🔔 Hawl complete — calculate and pay your Zakat now' (red)
Display-only urgency surface; no state, schema, or API changes.
4 dedicated tests (30d, 1d singular, complete, quiet-at-start).

Verified: client 458 pass/15 skip (= baseline + 4), build + PWA precache OK.
