### PR TITLE
Release v0.14.0 — Ikhlas Night & Security Sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,44 @@
 # Changelog
 
+## [0.14.0] - 2026-09-03 (interim release — ahead of the Jumada al-Thani cycle)
+
+### 🌙 Ikhlas Night & Security Sweep — Dark Mode, Dependency Hardening, Code Health
+
+#### Security (P1)
+- **Server production deps: 7 → 0 vulnerabilities**: undici (TLS-bypass/DoS family), deepmerge-ts,
+  body-parser (DoS), morgan (log forging) bumped via `npm audit fix`; `qs` pinned to `^6.16.0`
+  via overrides (3 DoS advisories under express/body-parser) (#332)
+- **Client production deps: 10 → 2**: brace-expansion (3 DoS), fast-uri (host confusion),
+  @grpc/grpc-js (crash DoS), rxdb's pinned ws (memory disclosure/DoS) & ajv (ReDoS) cleared;
+  react-router-dom patched to 6.30.6. The 2 remaining moderates are react-router 6.x — fix is
+  v7-only (breaking), both advisories SSR-specific and this is a plain SPA; tracked in #339 (#332)
+- Superseded conflicting Dependabot PR #325 (brace-expansion 5.0.9 covers all three advisories repo-wide)
+
+#### UX / Features
+- **Dark mode — "Ikhlas Night"**: class-strategy, fully additive. New `.dark` token set
+  (deep navy-teal + brighter turquoise/gold), retrofit overrides adapt the ~415 hardcoded
+  slate/white utilities without touching component markup; `useTheme` hook (localStorage +
+  system-preference) and header sun/moon toggle. Light mode is pixel-identical (#336)
+- **Hawl countdown milestones** on the dashboard ActiveRecordWidget: "Zakat due soon — N days
+  left" at ≤30 days, "Hawl complete — calculate and pay now" at 0 days. First deliverable of
+  the blue-ocean competitive-research workstream (automated Hawl/due-date tracking) (#337)
+
+#### Code health
+- **#320 closed**: 87 server + 58 client unused imports removed AST-safely via
+  `eslint-plugin-unused-imports` (server+client eslint configs added/extended); unused-variable
+  triage deferred to #340 (#335)
+- **WCAG 2.1 AA a11y suite revived** (5 jest-axe tests over Dashboard, AssetList,
+  NisabYearRecordsPage, PaymentsPage, Layout) + 2 heading-order violations fixed (#333)
+- Follow-up issues filed: #338 (i18n), #339 (react-router v7), #340 (unused-var triage),
+  #341 (NisabYearRecordsPage modal extraction)
+
+#### Tests
+- Server suite: 461 passing (unchanged — no server behavior touched)
+- Client suite: 458 passing, 15 skipped (up from 445: +5 a11y, +4 useTheme, +4 Hawl countdown)
+- Client PWA build verified (73-entry precache) on every PR
+
+**Full Changelog**: https://github.com/slimatic/zakapp/compare/v0.13.0...v0.14.0
+
 ## [0.13.0] - 2026-10-12 (Jumada al-Ula 1448 cycle)
 
 ### 🚀 Muharram 1448 Stabilization Release — Data Safety, Auth Hardening, Repo Hygiene

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -82,9 +82,9 @@ This roadmap prioritizes the transformation of ZakApp into a pro-grade, privacy-
 - [x] **Financial Precision**: Replace `parseFloat`/`parseInt` with Decimal.js in financial calculations.
 - [x] **Large File Refactors**:
   - [x] Split `AssetForm.tsx` (850 lines) into smaller components.
-  - [ ] Extract modals from `NisabYearRecordsPage.tsx` (717 lines).
+  - [ ] Extract modals from `NisabYearRecordsPage.tsx` (717 lines). *(tracked in #341)*
   - [x] Extract crypto/sync logic from `AuthContext.tsx` (669 lines) to `AuthService.ts`.
-- [ ] **Unused Imports**: Run ESLint auto-fix to remove unused imports across all files. *(deferred to v0.14 — needs `eslint-plugin-unused-imports`; see #320)*
+- [x] **Unused Imports**: Run ESLint auto-fix to remove unused imports across all files. *(completed in v0.14.0 — AST-safe via `eslint-plugin-unused-imports`, PR #335; unused-variable triage tracked in #340)*
 - [x] **TODO Resolution**: Address remaining `TODO-HASH-OF-KEY` placeholders in AuthContext.
 
 ## Phase 8.5: v0.13.0 Stability Cycle (Muharram 1448 — Oct 2026)
@@ -94,6 +94,17 @@ This roadmap prioritizes the transformation of ZakApp into a pro-grade, privacy-
 - [x] **Password Reset**: Real token flow (crypto-random, persisted, emailed) + confirm-reset endpoint (#311, #327).
 - [x] **Session Invalidation**: Durable `UserSession` persistence; restart-surviving refresh rejection; real logout (#312, #328).
 - [x] **Release Cadence**: Hijri moon-cycle release process documented (`docs/release-cycle.md`).
+
+## Phase 8.6: v0.14.0 Cycle — Security Sweep, Dark Mode & Blue-Ocean Start (Sep 2026)
+*Goal: zero known prod-dependency vulnerabilities, dark mode, and the first competitive-research quick win.*
+
+- [x] **Security deps**: server prod 7→0 vulns, client prod 10→2 (residual = react-router v7-only, #339) (#332)
+- [x] **Dark mode "Ikhlas Night"**: additive class-strategy theme + header toggle, zero light-mode change (#336)
+- [x] **Hawl countdown milestones**: due-soon / hawl-complete urgency on the dashboard (#337)
+- [x] **#320 unused imports**: AST-safe removal, eslint configs established (#335)
+- [x] **A11y suite revived**: WCAG 2.1 AA jest-axe tests + heading-order fixes (#333)
+- [ ] **Blue-ocean follow-ons**: multi-madhab transparency engine, retirement-account method options, family pooling *(spec needed — see zakapp-competitive-research.md)*
+- [ ] **i18n foundation** (#338)
 
 ## Phase 9: Technical Debt & Stability (Post-Launch)
 *Goal: Harden the development environment and ensure long-term maintainability.*

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zakapp/cli",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "CLI wizard for Zakapp",
   "main": "dist/index.js",
   "bin": {

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "private": true,
   "dependencies": {
     "@headlessui/react": "^2.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zakapp",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "A user-friendly, self-hosted Zakat application with modern UI",
   "main": "server/index.js",
   "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zakapp-server",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "zakapp backend server",
   "main": "index.js",
   "scripts": {

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zakapp/shared",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Shared types and utilities for zakapp",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## v0.14.0 Release

**Included PRs:** #332 (security deps: server 7→0, client 10→2 prod vulns), #333 (WCAG a11y suite revival), #335 (#320 unused imports, AST-safe), #336 (dark mode — Ikhlas Night), #337 (Hawl countdown milestones).

**Release contents:** CHANGELOG entry with compare link; version parity 0.14.0 across all 5 package.json files; ROADMAP Phase 8.6 added with completions + deferred items linked to new issues #338–#341.

**Test state:** server 461/461 · client 458 pass/15 skip · PWA build green (73-entry precache).

**Deploy plan (post-merge):** tag v0.14.0 → Docker Hub CI builds → Umbrel deploy with pre-deploy backup (backup-before-upgrade.sh) → external 200 checks on app/api/syncdb.