### PR TITLE
chore: Release v0.15.0 — Multi-Madhab Transparency Engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,43 @@
 # Changelog
 
+## [0.15.0] - 2026-09-04
+
+### 🕌 Multi-Madhab Transparency Engine — Per-Asset Rulings with Scholarly Citations
+
+#### Features
+- **Per-asset madhab ruling explanations** in the Zakat Calculator review step: every asset
+  now shows WHY it is zakatable or exempt under the chosen methodology, with the ruling,
+  plain-language reasoning, and named scholarly citations inline (#344)
+- **`AssetRulingExplanation` component**: expandable "Why?" per asset — status badge
+  (Zakatable / Exempt / your override), madhab-default explanation, override explanation when
+  the user's explicit `zakatEligible` setting differs from the madhab default, citation links
+  (Quran.com, sunnah.com, AAOIFI, SeekersGuidance, AMJA, FCNA), and scholar-consultation
+  disclaimer (#344)
+- **55-ruling registry** (`client/src/data/rulings.ts`): 5 methodologies × 11 asset types,
+  each with ruling + reasoning + citations. Pure `getAssetRuling()` mirrors the exact
+  decision chain of the calculation engine's `isAssetZakatable` — including the jewelry
+  exemption and explicit-override precedence — so explanations can never contradict the
+  numbers (#344)
+- **CI-enforced registry sync**: new test iterates every madhab × asset-type pair and fails
+  on missing/uncited rulings and on any parity drift with `isAssetZakatable` — the ruling
+  layer cannot silently diverge from the math (#344)
+- **Maliki and Hanbali educational content added** to `data/methodologies.ts` (previously
+  missing — only standard/hanafi/shafii/custom existed): full overview, historical context,
+  nisab rules, asset treatment, practical examples, sources; comparison table extended to
+  all schools (#344)
+
+#### Out of scope (follow-ups)
+- PDF report integration of the rulings
+- Compare-all-5-madhabs-on-my-portfolio view
+
+#### Tests
+- Server suite: 461 passing (unchanged — no server behavior touched)
+- Client suite: **471 passing, 15 skipped** (up from 458: +7 rulings registry,
+  +4 AssetRulingExplanation, +2 calculator rulings wiring)
+- Client PWA build verified (73-entry precache) on every PR
+
+**Full Changelog**: https://github.com/slimatic/zakapp/compare/v0.14.0...v0.15.0
+
 ## [0.14.0] - 2026-09-03 (interim release — ahead of the Jumada al-Thani cycle)
 
 ### 🌙 Ikhlas Night & Security Sweep — Dark Mode, Dependency Hardening, Code Health

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zakapp/cli",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "CLI wizard for Zakapp",
   "main": "dist/index.js",
   "bin": {

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "private": true,
   "dependencies": {
     "@headlessui/react": "^2.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zakapp",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "A user-friendly, self-hosted Zakat application with modern UI",
   "main": "server/index.js",
   "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zakapp-server",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "zakapp backend server",
   "main": "index.js",
   "scripts": {

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zakapp/shared",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Shared types and utilities for zakapp",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Release v0.15.0 — 🕌 Multi-Madhab Transparency Engine

Version bump 0.14.0 → 0.15.0 across all 5 packages + CHANGELOG entry.

**Headline feature (#344, already merged):** per-asset madhab ruling transparency — every asset in the calculator shows WHY it's zakatable/exempt under the chosen madhab, with rulings + scholarly citations inline. Maliki + Hanbali educational content added. 55-ruling registry with CI-enforced parity against the calc engine.

**Release gates (verified):**
- verify-zakapp-release.sh: ALL GATES PASSED (server 461 tests, client 471+15skip, TS compiles, CLI, shared build, no artifacts, no .beads)
- Secrets scan of diff: clean

**Post-merge:** tag v0.15.0 → GitHub Release (triggers docker-hub.yml semver build) → deploy to Umbrel production with pre-deploy backups.