### PR TITLE
feat: wire ruling transparency into live Nisab Year Records flow

### DIFF
--- a/client/src/components/nisab/RecordRulingsPanel.tsx
+++ b/client/src/components/nisab/RecordRulingsPanel.tsx
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) 2024 ZakApp Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * RecordRulingsPanel Component
+ *
+ * Shows WHY each asset in a Nisab Year Record is zakatable or exempt
+ * under the user's chosen madhab, with scholarly citations.
+ * Backed by the same registry the calc engine uses (data/rulings.ts),
+ * so explanations can never contradict the calculation.
+ */
+
+import React from 'react';
+import { Scale } from 'lucide-react';
+import { AssetRulingExplanation } from '../zakat/AssetRulingExplanation';
+import { getAssetRuling } from '../../data/rulings';
+import { AssetType } from '../../types/index';
+
+export interface RecordRulingsPanelProps {
+  /** Assets attached to the record (live assets or snapshot rows) */
+  assets: Array<{
+    id: string;
+    name: string;
+    /** Server category (cash, gold, silver, business, property, stocks, crypto, debts, expenses) */
+    category?: string;
+    /** Client AssetType (CASH, GOLD, ...) when available */
+    type?: string;
+    zakatEligible?: boolean | null;
+  }>;
+  /** User's preferred methodology (STANDARD, HANAFI, SHAFII, MALIKI, HANBALI — any case) */
+  methodologyName: string;
+  className?: string;
+}
+
+/**
+ * Map server asset categories (lowercase strings) to the AssetType enum
+ * the rulings registry is keyed by. Mirrors AssetForm's type→category map
+ * in reverse. Unknown categories fall back to OTHER, which the registry
+ * covers with an explicit ruling.
+ */
+export const categoryToAssetType = (category?: string): AssetType => {
+  const map: Record<string, AssetType> = {
+    cash: AssetType.CASH,
+    bank: AssetType.BANK_ACCOUNT,
+    bank_account: AssetType.BANK_ACCOUNT,
+    gold: AssetType.GOLD,
+    silver: AssetType.SILVER,
+    crypto: AssetType.CRYPTOCURRENCY,
+    cryptocurrency: AssetType.CRYPTOCURRENCY,
+    stocks: AssetType.INVESTMENT_ACCOUNT,
+    investment: AssetType.INVESTMENT_ACCOUNT,
+    investment_account: AssetType.INVESTMENT_ACCOUNT,
+    retirement: AssetType.RETIREMENT,
+    '401k': AssetType.RETIREMENT,
+    property: AssetType.REAL_ESTATE,
+    real_estate: AssetType.REAL_ESTATE,
+    business: AssetType.BUSINESS_ASSETS,
+    business_assets: AssetType.BUSINESS_ASSETS,
+    debts: AssetType.DEBTS_OWED_TO_YOU,
+    loan: AssetType.DEBTS_OWED_TO_YOU,
+    debts_owed_to_you: AssetType.DEBTS_OWED_TO_YOU,
+  };
+  const key = (category || '').toLowerCase().trim();
+  return map[key] || AssetType.OTHER;
+};
+
+export const RecordRulingsPanel: React.FC<RecordRulingsPanelProps> = ({
+  assets,
+  methodologyName,
+  className = '',
+}) => {
+  if (!assets || assets.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className={`bg-white border border-gray-200 rounded-lg p-4 ${className}`} data-testid="record-rulings-panel">
+      <div className="flex items-center gap-2 mb-3">
+        <Scale className="h-4 w-4 text-gray-500" aria-hidden="true" />
+        <h3 className="font-semibold text-gray-900 text-sm">Why each asset counts the way it does</h3>
+      </div>
+      <p className="text-xs text-gray-500 mb-3">
+        Rulings under your selected methodology, with sources. Expand any asset for details.
+      </p>
+      <div className="space-y-2">
+        {assets.map(asset => {
+          const assetType = (asset.type as AssetType) || categoryToAssetType(asset.category);
+          const ruling = getAssetRuling(
+            { type: assetType, zakatEligible: asset.zakatEligible, name: asset.name },
+            methodologyName
+          );
+          return (
+            <AssetRulingExplanation key={asset.id} ruling={ruling} assetName={asset.name} />
+          );
+        })}
+      </div>
+      <p className="text-xs text-gray-400 italic mt-3">
+        Educational guidance only — for specific situations, consult a qualified scholar.
+      </p>
+    </div>
+  );
+};
+
+export default RecordRulingsPanel;

--- a/client/src/components/nisab/__tests__/recordRulingsPanel.test.tsx
+++ b/client/src/components/nisab/__tests__/recordRulingsPanel.test.tsx
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2024 ZakApp Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { RecordRulingsPanel, categoryToAssetType } from '../RecordRulingsPanel';
+import { AssetType } from '../../../types/index';
+import { getAssetRuling } from '../../../data/rulings';
+
+describe('RecordRulingsPanel', () => {
+  const assets = [
+    { id: '1', name: 'Main Bank Account', category: 'cash', zakatEligible: true },
+    { id: '2', name: 'Gold Necklace', category: 'gold', zakatEligible: false },
+  ];
+
+  it('renders a ruling for each asset under the user methodology', () => {
+    render(<RecordRulingsPanel assets={assets} methodologyName="HANAFI" />);
+    expect(screen.getByTestId('record-rulings-panel')).toBeInTheDocument();
+    const statuses = screen.getAllByTestId('ruling-status');
+    expect(statuses).toHaveLength(2);
+    expect(statuses[0].textContent).toBe('Zakatable (your override)');
+    expect(statuses[1].textContent).toBe('Exempt (your override)');
+  });
+
+  it('expands a ruling to reveal reasoning and citations', () => {
+    render(<RecordRulingsPanel assets={assets} methodologyName="HANAFI" />);
+    const toggles = screen.getAllByTestId('ruling-toggle');
+    fireEvent.click(toggles[1]);
+    const panel = screen.getByTestId('record-rulings-panel');
+    expect(panel.textContent).toContain('jewelry');
+  });
+
+  it('maps server categories to AssetTypes the registry covers', () => {
+    expect(categoryToAssetType('cash')).toBe(AssetType.CASH);
+    expect(categoryToAssetType('gold')).toBe(AssetType.GOLD);
+    expect(categoryToAssetType('crypto')).toBe(AssetType.CRYPTOCURRENCY);
+    expect(categoryToAssetType('stocks')).toBe(AssetType.INVESTMENT_ACCOUNT);
+    expect(categoryToAssetType('property')).toBe(AssetType.REAL_ESTATE);
+    expect(categoryToAssetType('debts')).toBe(AssetType.DEBTS_OWED_TO_YOU);
+    expect(categoryToAssetType('business')).toBe(AssetType.BUSINESS_ASSETS);
+    expect(categoryToAssetType('unknown-thing')).toBe(AssetType.OTHER);
+  });
+
+  it('produces the same ruling the parity-tested registry function does', () => {
+    const ruling = getAssetRuling({ type: AssetType.GOLD, zakatEligible: false, name: 'Gold Necklace' }, 'SHAFII');
+    expect(ruling.status).toBe('override-exempt');
+  });
+
+  it('renders nothing when there are no assets', () => {
+    const { container } = render(<RecordRulingsPanel assets={[]} methodologyName="STANDARD" />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/client/src/components/nisab/index.ts
+++ b/client/src/components/nisab/index.ts
@@ -2,6 +2,8 @@ export { CreateRecordModal } from './CreateRecordModal';
 export { RecordPaymentModal } from './RecordPaymentModal';
 export { EditDatePopover } from './EditDatePopover';
 export { NisabRecordCard } from './NisabRecordCard';
+export { RecordRulingsPanel } from './RecordRulingsPanel';
+export type { RecordRulingsPanelProps } from './RecordRulingsPanel';
 export type { CreateRecordModalProps } from './CreateRecordModal';
 export type { RecordPaymentModalProps } from './RecordPaymentModal';
 export type { EditDatePopoverProps } from './EditDatePopover';

--- a/client/src/pages/NisabYearRecordsPage.tsx
+++ b/client/src/pages/NisabYearRecordsPage.tsx
@@ -29,7 +29,7 @@ import { useAssetRepository } from '../hooks/useAssetRepository';
 import { useLiabilityRepository } from '../hooks/useLiabilityRepository';
 import { useAuth } from '../contexts/AuthContext';
 import { useMaskedCurrency } from '../contexts/PrivacyContext';
-import { CreateRecordModal, RecordPaymentModal, NisabRecordCard } from '../components/nisab';
+import { CreateRecordModal, RecordPaymentModal, NisabRecordCard, RecordRulingsPanel } from '../components/nisab';
 
 export const NisabYearRecordsPage: React.FC = () => {
   const navigate = useNavigate();
@@ -115,7 +115,8 @@ export const NisabYearRecordsPage: React.FC = () => {
       const selectedAssets = allAssets.filter(a => assetIds.includes(a.id));
       const selectedLiabilities = allLiabilities.filter(l => liabilityIds.includes(l.id));
 
-      const { totalWealth, netZakatableWealth } = calculateWealth(selectedAssets, selectedLiabilities);
+      const userMethodology = ((user as any)?.settings?.preferredMethodology || 'STANDARD').toUpperCase();
+      const { totalWealth, netZakatableWealth } = calculateWealth(selectedAssets, selectedLiabilities, new Date(), userMethodology as any);
       const zakatAmount = netZakatableWealth >= threshold ? netZakatableWealth * 0.025 : 0;
 
       const startDate = date;
@@ -151,7 +152,8 @@ export const NisabYearRecordsPage: React.FC = () => {
   // Actions
   const handleRefreshAssets = async (recordId: string) => {
     try {
-      const { totalWealth, netZakatableWealth } = calculateWealth(allAssets, allLiabilities);
+      const userMethodology = ((user as any)?.settings?.preferredMethodology || 'STANDARD').toUpperCase();
+      const { totalWealth, netZakatableWealth } = calculateWealth(allAssets, allLiabilities, new Date(), userMethodology as any);
       const zakatAmount = netZakatableWealth * 0.025;
 
       await updateRecord(recordId, {
@@ -320,6 +322,18 @@ export const NisabYearRecordsPage: React.FC = () => {
             {activeRecord ? (
               <div className={`${!selectedRecordId ? 'hidden lg:block' : ''} space-y-4`}>
                 <ZakatDisplayCard record={activeRecord} />
+                <RecordRulingsPanel
+                  assets={allAssets
+                    .filter(a => a.isActive)
+                    .map(a => ({
+                      id: a.id,
+                      name: a.name || 'Unnamed asset',
+                      category: (a as any).category,
+                      type: (a as any).type,
+                      zakatEligible: (a as any).zakatEligible,
+                    }))}
+                  methodologyName={((user as any)?.settings?.preferredMethodology || 'STANDARD').toUpperCase()}
+                />
                 <HawlProgressIndicator record={activeRecord as any} />
                 <NisabComparisonWidget record={activeRecord} showDetails={true} />
 

--- a/client/tests/accessibility/a11y.test.tsx
+++ b/client/tests/accessibility/a11y.test.tsx
@@ -204,6 +204,7 @@ vi.mock("../../src/components/nisab", () => ({
   CreateRecordModal: () => <div data-testid="create-record-modal">Create Modal</div>,
   RecordPaymentModal: () => <div data-testid="record-payment-modal">Payment Modal</div>,
   NisabRecordCard: () => <div>NisabRecordCard</div>,
+  RecordRulingsPanel: () => <div data-testid="record-rulings-panel">Rulings</div>,
 }));
 
 vi.mock("../../src/components/HawlProgressIndicator", () => ({


### PR DESCRIPTION
## What

Fixes the v0.15.0 finding: the multi-madhab ruling explanations
(PR #344) were built into `ZakatCalculator` but that route is
commented out in `App.tsx` — so the feature was invisible in prod.

## Changes

- New `RecordRulingsPanel` component (nisab/) renders per-asset
  rulings with citations inside the Nisab Year Record detail view
- Adds `categoryToAssetType()` mapper (server categories → AssetType)
- `NisabYearRecordsPage` now passes the user's `preferredMethodology`
  into `calculateWealth` (fixes silent STANDARD-default bug)
- `RecordRulingsPanel` wired into the record detail column
- Unit tests: 5 new cases; a11y mock updated