### PR TITLE
fix: re-enable /calculator route + add route-reachability test

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -75,7 +75,7 @@ const AssetImportExport = lazy(() => import('./components/assets').then(m => ({ 
 const AssetDetails = lazy(() => import('./components/assets').then(m => ({ default: m.AssetDetails })));
 
 // Zakat calculation and history
-// const ZakatCalculator = lazy(() => import('./components/zakat/ZakatCalculator').then(m => ({ default: m.ZakatCalculator })));
+const ZakatCalculator = lazy(() => import('./components/zakat/ZakatCalculator').then(m => ({ default: m.ZakatCalculator })));
 // const History = lazy(() => import('./components/history/History').then(m => ({ default: m.History })));
 
 // Auth pages - lazy loaded as they're separate flows
@@ -229,9 +229,23 @@ function App() {
                       }
                     />
 
+                    {/* Standalone Zakat Calculator (quick-mode) */}
+                    <Route
+                      path="/calculator"
+                      element={
+                        <ProtectedRoute>
+                          <Layout>
+                            <Suspense fallback={<PageLoadingFallback />}>
+                              <ZakatCalculator />
+                            </Suspense>
+                          </Layout>
+                        </ProtectedRoute>
+                      }
+                    />
+
                     {/* History route hidden pending future implementation */}
-                    {/* <Route 
-                path="/history" 
+                    {/* <Route
+                path="/history"
                 element={
                   <ProtectedRoute>
                     <Layout>

--- a/client/src/__tests__/unit/appRouteReachability.test.ts
+++ b/client/src/__tests__/unit/appRouteReachability.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2024 ZakApp Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Feature-reachability gate (introduced after the v0.15.0 finding where
+ * ZakatCalculator was commented out of App.tsx and the feature shipped dead).
+ *
+ * Every page component in the codebase that has a top-level route MUST be
+ * imported in App.tsx and registered in a <Route> element. This test reads
+ * the live App.tsx source and fails if any "public page" page component is
+ * not mounted.
+ */
+describe('App.tsx route reachability', () => {
+  const appTsx = fs.readFileSync(
+    path.join(__dirname, '..', '..', 'App.tsx'),
+    'utf-8'
+  );
+
+  // Page components that must be reachable from a route. Each entry is
+  // either already exported as a default from its file, or has a known
+  // named export wired into App.tsx via a `lazy(() => import('...').then(m => ({ default: m.X })))`.
+  // Update this list when adding/removing public pages.
+  //
+  // Regex must be a word-boundary match on the export name; e.g. use
+  // `ZakatCalculator` (not `ZakatCalculatorComponent`) so commented-out
+  // siblings with similar names don't false-positive.
+  const requiredPublicPages: Array<{ importPath: RegExp; componentName: string }> = [
+    { importPath: /\bZakatCalculator\b/, componentName: 'ZakatCalculator' },
+    { importPath: /\bNisabYearRecordsPage\b/, componentName: 'NisabYearRecordsPage' },
+    { importPath: /\bconst Dashboard\b/, componentName: 'Dashboard' },
+  ];
+
+  for (const { importPath, componentName } of requiredPublicPages) {
+    it(`imports ${componentName} into App.tsx (not commented out)`, () => {
+      // Find a line that mentions the component name
+      const lines = appTsx.split('\n').filter(l => importPath.test(l));
+      expect(lines.length, `${componentName} not found in App.tsx`).toBeGreaterThan(0);
+      // None of those lines may be commented out (//)
+      const commented = lines.filter(l => l.trim().startsWith('//'));
+      expect(commented, `${componentName} appears only in commented lines:\n${commented.join('\n')}`).toHaveLength(0);
+    });
+  }
+
+  it('ZakatCalculator is mounted on a /calculator Route', () => {
+    expect(appTsx).toMatch(/path=["']\/calculator["']/);
+  });
+});

--- a/client/src/components/layout/Layout.tsx
+++ b/client/src/components/layout/Layout.tsx
@@ -130,6 +130,7 @@ export const Layout: React.FC<LayoutProps> = ({ children }) => {
       items: [
         { name: 'Assets', href: '/assets' },
         { name: 'Liabilities', href: '/liabilities' },
+        { name: 'Quick Calculator', href: '/calculator' },
       ]
     },
     {


### PR DESCRIPTION
## What
Re-enables the standalone Zakat Calculator route that was commented out of `App.tsx` (line ~78). The component has been built and exported, but the route was disabled.

## Why
- The ruling-transparency engine (PR #344/#346) is only fully visible via the live Nisab Year Records flow. The standalone calculator is a "quick mode" entry point that surfaces the same ruling panel + madhab selector without forcing users to create a record.
- Disabling routes silently is a class of bug the v0.15.0 release taught us to guard against — we now have a test.

## Changes
- `client/src/App.tsx` — uncomments the `ZakatCalculator` lazy import, adds a `/calculator` route under `ProtectedRoute + Layout + Suspense` with `PageLoadingFallback`
- `client/src/components/layout/Layout.tsx` — adds 'Quick Calculator' entry to the desktop Wealth nav group (mobile nav deliberately untouched — its `navigation` array has index-stability invariants)
- `client/src/__tests__/unit/appRouteReachability.test.ts` — new test (4 cases):
  - ZakatCalculator, NisabYearRecordsPage, Dashboard all imported into App.tsx (not commented)
  - `/calculator` route exists
  - Verified: temporarily commenting the import → test fails. Restoring → test passes.

## Verification
- `tsc --noEmit` — clean
- Client suite: **480 passed, 15 skipped** (4 new reachability cases)
- Server suite: **461 passed**
- Client `npm run build` — clean (PWA precache 78 entries, 5682 KiB)
- A11y suite: 53/53 (no regression)

## Not in scope
- Session invalidation (#312) — already closed
- Password reset email (#311) — already closed (6/6 integration tests pass)
- Re-enabling `/history` — same dead-route class but the underlying History component has a wider TODO list; out of scope here.