### PR TITLE
fix(currency): complete #310 — user currency end-to-end (server + client)

### DIFF
--- a/client/src/components/assets/AssetList.tsx
+++ b/client/src/components/assets/AssetList.tsx
@@ -25,6 +25,7 @@ import { useUserSettingsRepository } from '../../hooks/useUserSettingsRepository
 import { getAssetZakatableValue, ZakatMethodology } from '../../core/calculations/zakat';
 import { Button, Card } from '../ui';
 import { usePrivacy } from '../../contexts/PrivacyContext';
+import { useAuth } from '../../contexts/AuthContext';
 
 export const AssetList: React.FC = () => {
   const navigate = useNavigate();
@@ -44,6 +45,9 @@ export const AssetList: React.FC = () => {
 
   const { settings } = useUserSettingsRepository();
   const methodology = (settings?.preferredMethodology?.toUpperCase() || 'STANDARD') as ZakatMethodology;
+  // Currency resolution (#310): settings repo first, then auth-context profile, then USD.
+  const { user } = useAuth();
+  const userCurrency = (settings as any)?.currency || (user as any)?.settings?.currency || (user as any)?.preferences?.currency || 'USD';
 
   const { totalAssets, estimatedZakat } = useMemo(() => {
     const total = assets.reduce((sum, asset) => sum + asset.value, 0);
@@ -57,11 +61,11 @@ export const AssetList: React.FC = () => {
     };
   }, [assets, methodology]);
 
-  const formatCurrency = (value: number, currency = 'USD') => {
+  const formatCurrency = (value: number, currency?: string) => {
     if (privacyMode) return '****';
     return new Intl.NumberFormat('en-US', {
       style: 'currency',
-      currency: currency,
+      currency: currency || userCurrency,
       maximumFractionDigits: 0
     }).format(value);
   };

--- a/client/src/components/dashboard/ActiveRecordWidget.tsx
+++ b/client/src/components/dashboard/ActiveRecordWidget.tsx
@@ -17,6 +17,7 @@
 
 import React, { useMemo } from 'react';
 import { Link } from 'react-router-dom';
+import { useAuth } from '../../contexts/AuthContext';
 import { useMaskedCurrency } from '../../contexts/PrivacyContext';
 import { useNisabThreshold } from '../../hooks/useNisabThreshold';
 import { usePaymentRepository } from '../../hooks/usePaymentRepository';
@@ -47,10 +48,13 @@ interface ActiveRecordWidgetProps {
  */
 export const ActiveRecordWidget: React.FC<ActiveRecordWidgetProps> = ({ record }) => {
   const maskedCurrency = useMaskedCurrency();
+  const { user } = useAuth();
+  const userCurrency = (user as any)?.settings?.currency || (user as any)?.preferences?.currency || 'USD';
 
-  // Get live Nisab threshold for consistency
+  // Get live Nisab threshold for consistency — in the USER's currency (#310),
+  // not hardcoded USD: an IDR user's hawl progress must be measured against an IDR nisab.
   const nisabBasis = (record?.nisabBasis || 'GOLD') as 'GOLD' | 'SILVER';
-  const { nisabAmount } = useNisabThreshold('USD', nisabBasis);
+  const { nisabAmount } = useNisabThreshold(userCurrency, nisabBasis);
 
   // Hooks must be called unconditionally. Prepare memoized values and queries
   // using safe accessors so they can be evaluated even if `record` is null.

--- a/client/src/components/dashboard/__tests__/ActiveRecordWidget.countdown.test.tsx
+++ b/client/src/components/dashboard/__tests__/ActiveRecordWidget.countdown.test.tsx
@@ -9,6 +9,13 @@ import { MemoryRouter } from 'react-router-dom';
 import { PrivacyProvider } from '../../../contexts/PrivacyContext';
 import { ActiveRecordWidget } from '../ActiveRecordWidget';
 
+vi.mock('../../../contexts/AuthContext', () => ({
+  useAuth: () => ({
+    user: { settings: { currency: 'USD' } },
+    updateLocalProfile: vi.fn(),
+  }),
+}));
+
 vi.mock('../../../hooks/useNisabThreshold', () => ({
   useNisabThreshold: () => ({ nisabAmount: 5000, isLoading: false }),
 }));

--- a/client/src/components/zakat/ZakatResults.tsx
+++ b/client/src/components/zakat/ZakatResults.tsx
@@ -32,6 +32,8 @@ interface ZakatCalculation {
     isZakatObligatory: boolean;
     zakatAmount: number;
     zakatRate: number;
+    currency?: string;
+    fxRateFromUSD?: number;
   };
   breakdown: {
     assetsByCategory: Array<{
@@ -87,7 +89,7 @@ export const ZakatResults: React.FC<ZakatResultsProps> = ({
   const formatCurrency = (amount: number): string => {
     return new Intl.NumberFormat('en-US', {
       style: 'currency',
-      currency: 'USD',
+      currency: calculation.summary?.currency || 'USD',
       minimumFractionDigits: 2
     }).format(amount);
   };

--- a/client/src/hooks/useZakatCalculation.ts
+++ b/client/src/hooks/useZakatCalculation.ts
@@ -37,6 +37,8 @@ export const useCalculateZakat = () => {
       includeAssets?: string[];
       includeLiabilities?: string[];
       customNisab?: number;
+      // Issue #310: display currency for the returned summary.
+      currency?: string;
     }) => {
       const response = await apiService.calculateZakat(options);
 
@@ -94,6 +96,8 @@ export const useCalculateZakatOptimistic = () => {
       includeAssets?: string[];
       includeLiabilities?: string[];
       customNisab?: number;
+      // Issue #310: display currency for the returned summary.
+      currency?: string;
     }) => {
       const response = await apiService.calculateZakat(options);
 

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -266,7 +266,8 @@ export const Dashboard: React.FC = () => {
 
   // Get Nisab threshold (use live value for consistency with other pages)
   const nisabBasis = (activeRecord?.nisabBasis || 'GOLD') as 'GOLD' | 'SILVER';
-  const { nisabAmount } = useNisabThreshold('USD', nisabBasis);
+  const userCurrency = (user as any)?.settings?.currency || (user as any)?.preferences?.currency || 'USD';
+  const { nisabAmount } = useNisabThreshold(userCurrency, nisabBasis);
   const nisabThreshold = nisabAmount || 5000; // Default fallback
 
   // Loading state
@@ -364,13 +365,13 @@ export const Dashboard: React.FC = () => {
             <WealthSummaryCard
               totalWealth={totalWealth}
               nisabThreshold={nisabThreshold}
-              currency={(user as any)?.preferences?.currency || 'USD'}
+              currency={(user as any)?.settings?.currency || (user as any)?.preferences?.currency || 'USD'}
             />
 
             <div className="bg-white rounded-lg shadow-md p-6 border border-gray-200">
               <AssetsBreakdownChart
                 assets={assets}
-                currency={(user as any)?.preferences?.currency || 'USD'}
+                currency={(user as any)?.settings?.currency || (user as any)?.preferences?.currency || 'USD'}
               />
             </div>
           </div>

--- a/client/src/pages/onboarding/steps/MetalsStep.tsx
+++ b/client/src/pages/onboarding/steps/MetalsStep.tsx
@@ -5,7 +5,10 @@ import { useMaskedCurrency } from '../../../contexts/PrivacyContext';
 
 export const MetalsStep: React.FC = () => {
     const { data, updateAsset, nextStep, prevStep } = useOnboarding();
-    const { goldPrice, silverPrice, isLoading } = useNisabThreshold('USD', 'GOLD'); // Fetch both
+    // Fetch metal prices in the USER's chosen currency (#310) — values entered
+    // during onboarding are saved in that currency, so USD prices would misstate wealth.
+    const userCurrency = data.settings?.currency || 'USD';
+    const { goldPrice, silverPrice, isLoading } = useNisabThreshold(userCurrency, 'GOLD');
     const maskedCurrency = useMaskedCurrency();
 
     // Auto-calculate values when grams change
@@ -54,7 +57,7 @@ export const MetalsStep: React.FC = () => {
                                 Gold (24k)
                             </label>
                             <span className="text-xs font-mono bg-amber-100 text-amber-800 px-2 py-1 rounded">
-                                Live: {isLoading ? '...' : formatCurrency(goldPrice || 0)}/g
+                                Live: {isLoading ? '...' : formatCurrency(goldPrice || 0)}/g · {userCurrency}
                             </span>
                         </div>
                         <div className="flex gap-4">

--- a/client/src/pages/onboarding/steps/ZakatSetupStep.tsx
+++ b/client/src/pages/onboarding/steps/ZakatSetupStep.tsx
@@ -20,7 +20,10 @@ export const ZakatSetupStep: React.FC = () => {
     const { addRecord } = useNisabRecordRepository();
     const { addPayment } = usePaymentRepository();
     const nisabBasis = (data.nisab.standard || 'GOLD').toUpperCase() as 'GOLD' | 'SILVER';
-    const { nisabAmount, goldPrice, silverPrice } = useNisabThreshold('USD', nisabBasis);
+    // Use the user's chosen currency for nisab (#310) — onboarding saves asset
+    // values in that currency, so the threshold must be in the same currency.
+    const onboardingCurrency = data.settings?.currency || 'USD';
+    const { nisabAmount, goldPrice, silverPrice } = useNisabThreshold(onboardingCurrency, nisabBasis);
     const navigate = useNavigate();
     const currencySymbol = getCurrencySymbol((data.settings?.currency || 'USD') as any);
 

--- a/client/src/services/api.ts
+++ b/client/src/services/api.ts
@@ -352,6 +352,9 @@ class ApiService {
     includeAssets?: string[];
     includeLiabilities?: string[];
     customNisab?: number;
+    // Issue #310: display currency for the returned summary. Omitted →
+    // server resolves from the user's saved currency preference.
+    currency?: string;
   }): Promise<ApiResponse> {
     const response = await fetch(`${API_BASE_URL}/zakat/calculate`, {
       method: 'POST',

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -98,6 +98,7 @@ export interface ZakatCalculation {
   zakatDue: number;
   methodology: ZakatMethodology;
   currency: string;
+  fxRateFromUSD?: number;
   calculatedAt: string;
   assets: Asset[];
   nisabMethod: 'GOLD' | 'SILVER' | 'DUAL';

--- a/server/src/routes/zakat.ts
+++ b/server/src/routes/zakat.ts
@@ -25,9 +25,16 @@ import { ZakatEngine } from '../services/zakatEngine';
 import { CurrencyService } from '../services/currencyService';
 import { CalendarService } from '../services/calendarService';
 import { NisabService } from '../services/NisabService';
+import { UserService } from '../services/UserService';
 import { PaymentRecordService } from '../services/payment-record.service';
 import { CalculationHistoryService } from '../services/CalculationHistoryService';
 import { PaymentRecordsController } from '../controllers/payment-records.controller';
+import { Logger } from '../utils/logger';
+
+// Issue #310: currencies the platform supports for display/conversion.
+// Mirrors the client CURRENCY_CONFIG list in client/src/utils/formatters.ts.
+const SUPPORTED_CURRENCIES = ['USD', 'EUR', 'GBP', 'SAR', 'AED', 'EGP', 'TRY', 'INR', 'PKR', 'BDT', 'MYR', 'IDR'];
+const logger = new Logger('ZakatRoutes');
 import { z } from 'zod';
 import * as jwt from 'jsonwebtoken';
 import { prisma } from '../utils/prisma';
@@ -75,7 +82,11 @@ const ZakatCalculationRequestSchema = z.object({
   calculationDate: z.string().optional(), // ISO date, defaults to today
   includeAssets: z.array(z.string()).optional(), // Asset IDs to include
   includeLiabilities: z.array(z.string()).optional(), // Liability IDs to include
-  customNisab: z.number().optional() // Custom nisab threshold
+  customNisab: z.number().optional(), // Custom nisab threshold
+  // Issue #310: display currency for the calculation result. If omitted the
+  // server resolves it from the authenticated user's saved currency preference.
+  // The engine still computes in USD internally and converts the OUTPUT.
+  currency: z.string().length(3).optional()
 });
 
 /**
@@ -172,6 +183,46 @@ router.post('/calculate',
 
       const netWorth = result.result.totals.totalAssets - liabilityData.total;
 
+      // Issue #310: present results in the USER's currency. The engine computes
+      // in USD internally; convert the OUTPUT numbers so an IDR user sees IDR
+      // totals and an IDR nisab. Resolution order: explicit request currency →
+      // user's saved preference → USD.
+      let displayCurrency = typeof req.body.currency === 'string' ? req.body.currency.toUpperCase() : '';
+      if (!displayCurrency) {
+        try {
+          const settings = await new UserService().getSettings(req.userId!);
+          const saved = (settings as { currency?: string }).currency;
+          if (typeof saved === 'string' && saved.trim()) displayCurrency = saved.toUpperCase();
+        } catch {
+          // Settings unavailable — fall through to USD
+        }
+      }
+      if (!SUPPORTED_CURRENCIES.includes(displayCurrency)) displayCurrency = 'USD';
+
+      let presentation = {
+        totalAssets: result.result.totals.totalAssets,
+        totalZakatDue: result.result.totals.totalZakatDue,
+        netWorth,
+        nisabThreshold: result.result.nisab.effectiveNisab
+      };
+      let fxRate = 1.0;
+      if (displayCurrency !== 'USD') {
+        try {
+          fxRate = await currencyService.getExchangeRate('USD', displayCurrency);
+          presentation = {
+            totalAssets: presentation.totalAssets * fxRate,
+            totalZakatDue: presentation.totalZakatDue * fxRate,
+            netWorth: presentation.netWorth * fxRate,
+            nisabThreshold: presentation.nisabThreshold * fxRate
+          };
+        } catch (err) {
+          logger.warn(`FX conversion to ${displayCurrency} failed, presenting USD: ${err instanceof Error ? err.message : err}`);
+          displayCurrency = 'USD';
+          fxRate = 1.0;
+        }
+      }
+      const displayNetWorth = presentation.netWorth;
+
       const savedCalculation = await prisma.zakatCalculation.create({
         data: {
           userId: req.userId!,
@@ -230,14 +281,16 @@ router.post('/calculate',
           methodology: result.methodology.id,
           calendarType: result.result.calendarType,
           summary: {
-            totalAssets: result.result.totals.totalAssets,
-            totalLiabilities: liabilityData.total,
-            netWorth,
-            nisabThreshold: result.result.nisab.effectiveNisab,
-            nisabSource: result.result.nisab.nisabBasis,
-            isZakatObligatory: result.result.meetsNisab,
-            zirconYearAmount: result.result.totals.totalZakatDue,
-            zirconYearRate: result.methodology.zakatRate
+          totalAssets: presentation.totalAssets,
+          totalLiabilities: liabilityData.total,
+          netWorth: displayNetWorth,
+          nisabThreshold: presentation.nisabThreshold,
+          nisabSource: result.result.nisab.nisabBasis,
+          isZakatObligatory: result.result.meetsNisab,
+          zakatDue: presentation.totalZakatDue,
+          zakatRate: result.methodology.zakatRate,
+          currency: displayCurrency,
+          fxRateFromUSD: fxRate
           },
            breakdown: {
              assetsByCategory: groupAssetsByCategory(result.result.assets),
@@ -272,24 +325,46 @@ router.post('/calculate',
  * GET /api/zakat/nisab
  * Get current nisab thresholds (matches API contract)
  */
-router.get('/nisab', async (req, res: Response) => {
+router.get('/nisab', authenticate, async (req: AuthenticatedRequest, res: Response) => {
   try {
     const nisabService = new NisabService();
+    const userService = new UserService();
+    const logger = new Logger('ZakatRoutes');
 
-    // Get nisab information for standard methodology
-    const nisabInfo = await nisabService.calculateNisab('standard', 'USD');
+    // Currency resolution order (issue #310):
+    // 1. Explicit ?currency= query param (explicit user intent for this call)
+    // 2. Authenticated user's saved currency preference (settings.currency, encrypted blob)
+    // 3. USD fallback
+    // Never silently default to USD when the user has a preference — an IDR user
+    // must get an IDR nisab or their zakat due is mis-stated by the FX rate.
+    const SUPPORTED_CURRENCIES = ['USD', 'EUR', 'GBP', 'SAR', 'AED', 'EGP', 'TRY', 'INR', 'PKR', 'BDT', 'MYR', 'IDR'];
+    let currency = typeof req.query.currency === 'string' ? req.query.currency.toUpperCase() : '';
+    if (!currency) {
+      try {
+        const settings = await userService.getSettings(req.userId!);
+        const saved = (settings as { currency?: string }).currency;
+        if (typeof saved === 'string' && saved.trim()) currency = saved.toUpperCase();
+      } catch (err) {
+        logger.warn(`Could not load user currency preference, falling back to USD: ${err instanceof Error ? err.message : err}`);
+      }
+    }
+    if (!SUPPORTED_CURRENCIES.includes(currency)) currency = 'USD';
+
+    const methodology = typeof req.query.methodology === 'string' ? req.query.methodology : 'standard';
+    const nisabInfo = await nisabService.calculateNisab(methodology, currency);
 
     const response = createResponse(true, {
       effectiveDate: new Date().toISOString(),
+      currency,
       goldPrice: {
         pricePerGram: nisabInfo.goldNisab / 87.48, // Approximate grams for gold nisab
-        currency: 'USD',
+        currency,
         nisabGrams: 87.48,
         nisabValue: nisabInfo.goldNisab
       },
       silverPrice: {
         pricePerGram: nisabInfo.silverNisab / 612.36, // Approximate grams for silver nisab
-        currency: 'USD',
+        currency,
         nisabGrams: 612.36,
         nisabValue: nisabInfo.silverNisab
       },

--- a/server/src/routes/zakat.ts
+++ b/server/src/routes/zakat.ts
@@ -18,7 +18,7 @@
 import * as express from 'express';
 import { Response, Request } from 'express';
 import { AuthenticatedRequest } from '../types';
-import { authenticate } from '../middleware/AuthMiddleware';
+import { authenticate, optionalAuthenticate } from '../middleware/AuthMiddleware';
 import { validateSchema } from '../middleware/ValidationMiddleware';
 import { asyncHandler } from '../middleware/ErrorHandler';
 import { ZakatEngine } from '../services/zakatEngine';
@@ -201,6 +201,7 @@ router.post('/calculate',
 
       let presentation = {
         totalAssets: result.result.totals.totalAssets,
+        totalLiabilities: liabilityData.total,
         totalZakatDue: result.result.totals.totalZakatDue,
         netWorth,
         nisabThreshold: result.result.nisab.effectiveNisab
@@ -211,6 +212,7 @@ router.post('/calculate',
           fxRate = await currencyService.getExchangeRate('USD', displayCurrency);
           presentation = {
             totalAssets: presentation.totalAssets * fxRate,
+            totalLiabilities: presentation.totalLiabilities * fxRate,
             totalZakatDue: presentation.totalZakatDue * fxRate,
             netWorth: presentation.netWorth * fxRate,
             nisabThreshold: presentation.nisabThreshold * fxRate
@@ -273,7 +275,48 @@ router.post('/calculate',
         // Note: Failed to save calculation to history
       }
 
-      // Transform result to match API contract format
+      // Issue #310 (review fix B2): convert breakdown money fields into the
+      // display currency so they match summary.totalAssets / summary.currency.
+      const convertBreakdown = (breakdown: typeof result.breakdown) => {
+        const scaleCategories = (categories: Array<{ category: string; totalValue: number; assetCount: number; assets: Array<Record<string, unknown>> }>) =>
+          categories.map(cat => ({
+            ...cat,
+            totalValue: cat.totalValue * fxRate,
+            assets: cat.assets.map(asset => ({
+              ...asset,
+              value: typeof asset.value === 'number' ? asset.value * fxRate : asset.value,
+              zakatableValue: typeof asset.zakatableValue === 'number' ? asset.zakatableValue * fxRate : asset.zakatableValue,
+              zakatAmount: typeof asset.zakatAmount === 'number' ? asset.zakatAmount * fxRate : asset.zakatAmount
+            }))
+          }));
+
+        return {
+          ...breakdown,
+          assetCalculations: Array.isArray((breakdown as Record<string, unknown>).assetCalculations)
+            ? (breakdown as { assetCalculations: Array<Record<string, unknown>> }).assetCalculations.map((calc: Record<string, unknown>) => ({
+                ...calc,
+                totalValue: typeof calc.totalValue === 'number' ? calc.totalValue * fxRate : calc.totalValue,
+                zakatableValue: typeof calc.zakatableValue === 'number' ? calc.zakatableValue * fxRate : calc.zakatableValue,
+                zakatAmount: typeof calc.zakatAmount === 'number' ? calc.zakatAmount * fxRate : calc.zakatAmount
+              }))
+            : (breakdown as Record<string, unknown>).assetCalculations,
+          assetsByCategory: scaleCategories(groupAssetsByCategory(result.result.assets)),
+          liabilities: liabilityData.liabilities.map(l => ({
+            ...l,
+            amount: l.amount * fxRate
+          })),
+          methodologyRules: {
+            nisabCalculation: {
+              ...result.result.nisab,
+              effectiveNisab: result.result.nisab.effectiveNisab * fxRate
+            },
+            assetTreatment: result.methodology.businessAssetTreatment,
+            liabilityDeduction: result.methodology.debtDeduction
+          }
+        };
+      };
+      const convertedBreakdown = convertBreakdown(result.breakdown);
+
       const response = createResponse(true, {
         calculation: {
           id: savedCalculation.id,
@@ -282,7 +325,7 @@ router.post('/calculate',
           calendarType: result.result.calendarType,
           summary: {
           totalAssets: presentation.totalAssets,
-          totalLiabilities: liabilityData.total,
+          totalLiabilities: presentation.totalLiabilities,
           netWorth: displayNetWorth,
           nisabThreshold: presentation.nisabThreshold,
           nisabSource: result.result.nisab.nisabBasis,
@@ -292,17 +335,9 @@ router.post('/calculate',
           currency: displayCurrency,
           fxRateFromUSD: fxRate
           },
-           breakdown: {
-             assetsByCategory: groupAssetsByCategory(result.result.assets),
-             liabilities: liabilityData.liabilities,
-             methodologyRules: {
-               nisabCalculation: result.result.nisab,
-               assetTreatment: result.methodology.businessAssetTreatment,
-               liabilityDeduction: result.methodology.debtDeduction
-             }
-           },
+           breakdown: convertedBreakdown,
           educationalContent: {
-            nisabExplanation: `Nisab threshold of ${result.result.nisab.effectiveNisab} based on ${result.result.nisab.nisabBasis}`,
+            nisabExplanation: `Nisab threshold of ${presentation.nisabThreshold} based on ${result.result.nisab.nisabBasis}`,
             methodologyExplanation: result.methodology.explanation,
             scholarlyReferences: result.methodology.scholarlyBasis
           }
@@ -325,7 +360,7 @@ router.post('/calculate',
  * GET /api/zakat/nisab
  * Get current nisab thresholds (matches API contract)
  */
-router.get('/nisab', authenticate, async (req: AuthenticatedRequest, res: Response) => {
+router.get('/nisab', optionalAuthenticate, async (req: AuthenticatedRequest, res: Response) => {
   try {
     const nisabService = new NisabService();
     const userService = new UserService();
@@ -340,12 +375,16 @@ router.get('/nisab', authenticate, async (req: AuthenticatedRequest, res: Respon
     const SUPPORTED_CURRENCIES = ['USD', 'EUR', 'GBP', 'SAR', 'AED', 'EGP', 'TRY', 'INR', 'PKR', 'BDT', 'MYR', 'IDR'];
     let currency = typeof req.query.currency === 'string' ? req.query.currency.toUpperCase() : '';
     if (!currency) {
-      try {
-        const settings = await userService.getSettings(req.userId!);
-        const saved = (settings as { currency?: string }).currency;
-        if (typeof saved === 'string' && saved.trim()) currency = saved.toUpperCase();
-      } catch (err) {
-        logger.warn(`Could not load user currency preference, falling back to USD: ${err instanceof Error ? err.message : err}`);
+      // Only attempt preference lookup for authenticated callers (B3: route is
+      // optional-auth so pre-auth onboarding still works); anonymous → USD.
+      if (req.userId) {
+        try {
+          const settings = await userService.getSettings(req.userId);
+          const saved = (settings as { currency?: string }).currency;
+          if (typeof saved === 'string' && saved.trim()) currency = saved.toUpperCase();
+        } catch (err) {
+          logger.warn(`Could not load user currency preference, falling back to USD: ${err instanceof Error ? err.message : err}`);
+        }
       }
     }
     if (!SUPPORTED_CURRENCIES.includes(currency)) currency = 'USD';

--- a/server/tests/integration/currencyConsistency310.test.ts
+++ b/server/tests/integration/currencyConsistency310.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Copyright (c) 2024 ZakApp Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Issue #310 regression tests — currency consistency (round 3).
+ *
+ * The user (IDR) reported on v0.15 that Dashboard/assets/liabilities still
+ * show USD and the zakat calculation is computed on USD. Root causes found:
+ *
+ * 1. GET /api/zakat/nisab hardcoded 'USD' and ignored the user's preference.
+ * 2. Client useNisabThreshold call-sites hardcoded 'USD' (5 of 6 sites).
+ * 3. AssetList's local formatCurrency defaulted to 'USD'.
+ * 4. POST /api/zakat/calculate returned USD totals with no currency field.
+ *
+ * These tests pin the FIX CONTRACT so the class of bug cannot silently return.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// The server /nisab route source must not hardcode a calculateNisab currency
+// argument — it must resolve from query param or user settings.
+import fs from 'node:fs';
+import path from 'node:path';
+
+const readRepo = (rel: string) =>
+  fs.readFileSync(path.join(__dirname, rel), 'utf-8');
+
+describe('issue #310 — server currency resolution', () => {
+  let zakatRoutes: string;
+  beforeEach(() => {
+    zakatRoutes = readRepo('../../src/routes/zakat.ts');
+  });
+
+  it('/nisab endpoint no longer hardcodes USD in calculateNisab call', () => {
+    const nisabBlock = zakatRoutes.slice(
+      zakatRoutes.indexOf("router.get('/nisab'"),
+      zakatRoutes.indexOf("router.get('/nisab'") + 3000
+    );
+    expect(nisabBlock).not.toMatch(/calculateNisab\([^)]*'USD'/);
+    expect(nisabBlock).toMatch(/calculateNisab\(methodology,\s*currency\)/);
+  });
+
+  it('/nisab endpoint resolves user preference from encrypted settings', () => {
+    expect(zakatRoutes).toMatch(/getSettings\(req\.userId/);
+    expect(zakatRoutes).toMatch(/settings.*currency|currency.*settings/s);
+  });
+
+  it('/nisab endpoint accepts explicit ?currency= override', () => {
+    expect(zakatRoutes).toMatch(/req\.query\.currency/);
+  });
+
+  it('/nisab endpoint returns the resolved currency in the response', () => {
+    const nisabBlock = zakatRoutes.slice(
+      zakatRoutes.indexOf("router.get('/nisab'"),
+      zakatRoutes.indexOf("router.get('/nisab'") + 3500
+    );
+    expect(nisabBlock).toMatch(/currency,/);
+  });
+
+  it('/calculate accepts optional currency in request schema', () => {
+    expect(zakatRoutes).toMatch(/currency:\s*z\.string\(\)\.length\(3\)\.optional\(\)/);
+  });
+
+  it('/calculate converts the summary into the display currency', () => {
+    const calcBlock = zakatRoutes.slice(
+      zakatRoutes.indexOf("router.post('/calculate'"),
+      zakatRoutes.indexOf("router.post('/calculate'") + 12000
+    );
+    expect(calcBlock).toMatch(/getExchangeRate\('USD',\s*displayCurrency\)/);
+    expect(calcBlock).toMatch(/currency:\s*displayCurrency/);
+  });
+
+  it('exchange-rate failure falls back to USD, never a silent 1.0 mislabel', () => {
+    const calcBlock = zakatRoutes.slice(
+      zakatRoutes.indexOf("router.post('/calculate'"),
+      zakatRoutes.indexOf("router.post('/calculate'") + 14000
+    );
+    // On conversion failure the response must NOT claim the target currency
+    expect(calcBlock).toMatch(/displayCurrency = 'USD'/);
+  });
+});
+
+describe('issue #310 — client call-sites use the user currency', () => {
+  const clientRoot = path.join(__dirname, '..', '..', '..');
+
+  const cases: Array<{ file: string; mustMatch: RegExp; label: string }> = [
+    {
+      file: 'client/src/components/dashboard/ActiveRecordWidget.tsx',
+      mustMatch: /useNisabThreshold\(userCurrency,\s*nisabBasis\)/,
+      label: 'ActiveRecordWidget hawl widget',
+    },
+    {
+      file: 'client/src/pages/onboarding/steps/ZakatSetupStep.tsx',
+      mustMatch: /useNisabThreshold\(onboardingCurrency,\s*nisabBasis\)/,
+      label: 'ZakatSetupStep onboarding',
+    },
+    {
+      file: 'client/src/pages/onboarding/steps/MetalsStep.tsx',
+      mustMatch: /useNisabThreshold\(userCurrency,\s*'GOLD'\)/,
+      label: 'MetalsStep metal prices',
+    },
+  ];
+
+  for (const { file, mustMatch, label } of cases) {
+    it(`${label} passes a user-derived currency (no hardcoded USD)`, () => {
+      const src = fs.readFileSync(path.join(clientRoot, file), 'utf-8');
+      expect(src.match(mustMatch), `${label} still hardcodes USD`).toBeTruthy();
+      // And no remaining hardcoded 'USD' first-arg at a useNisabThreshold call
+      const hardcoded = src.match(/useNisabThreshold\(\s*'USD'/);
+      expect(hardcoded, `${label} hardcodes 'USD'`).toBeNull();
+    });
+  }
+
+  it('AssetList formatCurrency falls back to userCurrency, not USD', () => {
+    const src = fs.readFileSync(
+      path.join(clientRoot, 'client/src/components/assets/AssetList.tsx'),
+      'utf-8'
+    );
+    expect(src).toMatch(/currency:\s*currency \|\| userCurrency/);
+    expect(src).not.toMatch(/formatCurrency = \(value: number,\s*currency = 'USD'/);
+  });
+});


### PR DESCRIPTION
## Context

The #310 reporter came back on v0.15: IDR still shows USD on Dashboard/assets/liabilities and the zakat calculation is USD-based. PRs #318 (dropdowns) and #323 (some display formatters) were partial — the bug lived in three more layers.

## Root cause (all verified in code, not assumed)

1. **GET /api/zakat/nisab** hardcoded `calculateNisab('standard', 'USD')` — ignored the user's saved currency even though NisabService supported it
2. **5 of 6 client useNisabThreshold call-sites hardcoded 'USD'** — the calculation-level bug: an IDR user's onboarding saved a USD nisab against IDR assets → wrong zakat due
3. **POST /api/zakat/calculate** returned USD totals with no currency field
4. Display gaps missed in #323: AssetList formatter, pages/Dashboard hook, ZakatResults formatter

## Fix

**Server** (src/routes/zakat.ts)
- /nisab: currency resolution = ?currency= param → authenticated user's encrypted settings.currency → USD; validates against supported list; returns resolved currency
- /calculate: optional currency in zod schema; engine still computes USD internally (untouched — parity tests hold); output summary converted via CurrencyService; returns currency + fxRateFromUSD; on FX failure falls back to USD **honestly labeled**, never silent 1.0
- Removed misnamed zirconYearAmount/zirconYearRate → zakatDue/zakatRate (zero consumers, grep-verified)

**Client**
- ActiveRecordWidget, pages/Dashboard, ZakatSetupStep, MetalsStep pass user-derived currency into useNisabThreshold (IdentityStep stays USD deliberately — pre-selection step)
- AssetList formatCurrency → userCurrency fallback
- ZakatResults formatCurrency → calculation.summary.currency
- calculateZakat api + both mutation hooks accept currency
- WealthSummaryCard/AssetsBreakdownChart read settings.currency first

## Due diligence / test evidence

- **New regression suite** server/tests/integration/currencyConsistency310.test.ts (11 cases) pins the contract: source-greps prove no hardcoded USD at server or client call-sites, prove settings resolution + ?currency override + FX output conversion + honest fallback. Verified the test FAILS when the regression is reintroduced (revert experiment), passes on the fix.
- Server: **472/472** (46 files + 1 new)
- Client: **480 passed / 15 skipped** (added useAuth mock to ActiveRecordWidget countdown test tripped by the new hook)
- tsc --noEmit: both trees clean
- Client build: clean (PWA precache generated)
- Collateral sweep: grep for removed zirconYear* fields = zero consumers
- Also caught and fixed in this pass: pages/Dashboard.tsx:269 hardcoded USD (missed in first pass), ZakatResults.tsx:90 hardcoded USD, and a wrong property access in my own new code (calculation.currency → summary.currency) that tsc caught.

## Known follow-up (not in scope)

currencyService.getExchangeRate is still a mock rate table (IDR @ 15,750, Sept-2025-era) and zakatEngine falls back to rate 1.0 on conversion failure. The route-level fallback is now honest (labeled USD), but the mock table should be replaced with a live FX API in a dedicated issue — filing as follow-up.

Closes #310