### PR TITLE
chore(release): v0.15.2 — currency consistency final round (#350)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## [0.15.2] - 2026-09-10
+
+### 💱 Currency Consistency — Final Round of Issue #310
+
+User-facing summary: **Currency setting now sticks everywhere. Totals no longer mix currencies. App recovers instead of showing "You're Offline." Reloading on `/assets/` paths works again.**
+
+#### Fixed
+- **Currency setting now persists** (#350): changing currency in Settings used to silently revert on page reload. ProfileForm now writes both the profile blob *and* `settings.currency` via `PUT /api/user/settings`, reading current settings first so nothing in the encrypted blob is clobbered.
+- **Mixed-currency sums eliminated** (#350): Dashboard, AssetList, and NisabYearRecordsPage previously summed USD + IDR amounts directly (e.g. $500 + Rp 50M displayed as $50,000,500). A new `currencyNormalization.ts` util converts every amount to the display currency before summing, with a `converted` flag so a missing-FX state never silently displays apples+oranges. New server endpoint `GET /api/zakat/fx-rates` (USD base, optional auth) + `useFxRates` hook power the conversion.
+- **Nisab endpoint fallback for pre-fix users** (#350): `/api/zakat/nisab` now falls back to the profile store's currency for users whose `settings.currency` was never populated by the earlier fix.
+- **Client nisab cache keyed by currency** (#350): `getNisab(currency?)` now always sends `?currency=`; the query cache is keyed by currency. ZakatCalculator passes the user's currency, re-fetches on change, and its hardcoded `currency="USD"` payment modal is gone.
+- **"You're Offline" dead-end fixed** (#350): Workbox `navigateFallback` pointed to `/offline.html` which wasn't precached on all routes, leaving users stranded. Now points to `/index.html` so the SPA boots and routes correctly. `offline.html` remains precached for genuine offline use.
+- **nginx trailing-slash 403 fixed** (#350): `try_files` was probing `$uri/` for `/assets/` reloads, hitting autoindex-off 403 instead of falling through to the SPA. No longer probes the directory.
+
+#### API changes
+- New endpoint: `GET /api/zakat/fx-rates` — returns USD-base exchange rates for all supported currencies. Optional auth (authenticated callers get fresh rates; unauthenticated get cached).
+- `GET /api/zakat/nisab` now has a profile-store currency fallback.
+
+#### Honest caveat
+Mixed-currency totals convert at FX fetch time, so for the first second after a cold load the Dashboard may show "Updating exchange rates…" instead of a number — deliberate (wrong number replaced by honest placeholder).
+
+#### Tests
+- Server suite: **474 passing** (up from 472: +2 contract tests pinning the profile fallback + fx-rates endpoint)
+- Client suite: **504 passing / 15 skipped** (up from 480: +24 regression tests in `currencyRound4.test.ts` + `currencyNormalization.test.ts`)
+- Client `tsc --noEmit` clean; client build green; regenerated `sw.js` inspected and confirmed
+
+**Full Changelog**: https://github.com/slimatic/zakapp/compare/v0.15.1...v0.15.2
+
 ## [0.15.1] - 2026-09-10
 
 ### 💱 Currency Consistency — Server-Side Completion of Issue #310

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zakapp/cli",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "CLI wizard for Zakapp",
   "main": "dist/index.js",
   "bin": {

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "private": true,
   "dependencies": {
     "@headlessui/react": "^2.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zakapp",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "A user-friendly, self-hosted Zakat application with modern UI",
   "main": "server/index.js",
   "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zakapp-server",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "zakapp backend server",
   "main": "index.js",
   "scripts": {

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zakapp/shared",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "Shared types and utilities for zakapp",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Release v0.15.2

Version bump 0.15.1 → 0.15.2 across all 5 packages + CHANGELOG entry.

This is the final round of the #310 currency fix (PR #350, already merged to main). See CHANGELOG for the full user-facing summary:

- Currency setting now persists (was silently reverting)
- Mixed-currency sums eliminated (USD + IDR no longer added raw)
- Nisab endpoint fallback for pre-fix users
- Client nisab cache keyed by currency
- "You're Offline" dead-end fixed (SW navigateFallback → /index.html)
- nginx trailing-slash 403 fixed

Tests: server 474/474, client 504 pass/15 skip. tsc clean both trees. Build green.