### PR TITLE
fix(security): nodemailer 9.0.3 → 9.1.1 — clears 4 high-severity prod advisories

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zakapp-server",
-  "version": "0.13.0",
+  "version": "0.15.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zakapp-server",
-      "version": "0.13.0",
+      "version": "0.15.2",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@prisma/client": "^6.1.0",
@@ -34,7 +34,7 @@
         "morgan": "^1.10.1",
         "node-cron": "^4.2.1",
         "node-fetch": "^2.7.0",
-        "nodemailer": "^9.0.1",
+        "nodemailer": "^9.1.1",
         "redis": "^4.6.13",
         "resend": "^6.4.2",
         "tsconfig-paths": "^4.2.0",
@@ -74,7 +74,7 @@
     },
     "../shared": {
       "name": "@zakapp/shared",
-      "version": "0.13.0",
+      "version": "0.15.2",
       "dependencies": {
         "js-sha256": "^0.10.0",
         "zod": "^3.22.4"
@@ -5186,9 +5186,9 @@
       }
     },
     "node_modules/nodemailer": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.3.tgz",
-      "integrity": "sha512-n+YP+NKwR5zRWa60k3GiQ6Q3B4KXCoAw40dAKeCtYn020iNN74aWK2liXIC3ZEATeGql7we3tE3t8QwhY0eskw==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.1.1.tgz",
+      "integrity": "sha512-izw9mVKFix6YSnC9eLgV6g1opl9DUlRio9ZNcq+Wu9Ujn2UwF+8Nl0B8nz22kEC+CTZCvinkxwJ0DeFbb6NwcQ==",
       "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"

--- a/server/package.json
+++ b/server/package.json
@@ -47,7 +47,7 @@
     "morgan": "^1.10.1",
     "node-cron": "^4.2.1",
     "node-fetch": "^2.7.0",
-    "nodemailer": "^9.0.1",
+    "nodemailer": "^9.1.1",
     "redis": "^4.6.13",
     "resend": "^6.4.2",
     "tsconfig-paths": "^4.2.0",


### PR DESCRIPTION
## Security bump (P0, ships immediately per v0.14.0 precedent — not held for the cycle date)

**Advisories cleared** (all in `nodemailer`, prod dependency, range `<=9.1.0`):
- GHSA-8m3c-c648-2xjj — `resolveContent()` bypasses `disableFileAccess`/`disableUrlAccess` (legacy signature)
- GHSA-wmmp-3585-3rmp — IDN/Punycode domain allow-list bypass → delivery to attacker-controlled domain
- GHSA-2x7j-588g-ccc2 — quadratic complexity in `addressparser` → DoS via crafted address list
- GHSA-cc9r-2j5m-2m83 — RFC 5322 comment mis-parsing → recipient-domain validation bypass

## Changes
- `server/package.json`: `nodemailer ^9.0.1` → `^9.1.1` (resolved 9.0.3 → 9.1.1)
- `server/package-lock.json`: lockfile updated

## Verification
- [x] `npm audit --omit=dev`: **0 vulnerabilities** (was 1 high)
- [x] Server test suite: **474/474 passing**
- [x] `tsc --noEmit`: clean

Part of the Muharram 1448 audit → v0.16.0 plan: `docs/plans/2026-09-11-muharram-1448-audit-v0160-plan.md` (opening in a follow-up PR).