### PR TITLE
fix(annual-summary): read YearlySnapshot.methodologyUsed — stale TODO(#314) resolved

### DIFF
--- a/server/src/services/AnnualSummaryService.ts
+++ b/server/src/services/AnnualSummaryService.ts
@@ -233,7 +233,7 @@ export class AnnualSummaryService {
     const nisabInfo: Record<string, any> = {
       threshold: snapshot.nisabThreshold,
       type: snapshot.nisabType,
-      methodology: (snapshot as any).methodology || 'standard' // TODO(#314): Add methodology to YearlySnapshot schema
+      methodology: snapshot.methodologyUsed // YearlySnapshot.methodologyUsed (added with the hawl-tracking schema)
     };
 
     const totalZakatCalculated = snapshot.zakatAmount;
@@ -253,7 +253,7 @@ export class AnnualSummaryService {
       recipientSummary,
       assetBreakdown,
       comparativeAnalysis,
-      methodologyUsed: ((snapshot as any).methodologyUsed || (snapshot as any).methodology || 'standard') as ZakatMethodology, // TODO(#314): Add methodology to YearlySnapshot schema
+      methodologyUsed: snapshot.methodologyUsed as ZakatMethodology, // YearlySnapshot.methodologyUsed — real schema field (TODO(#314) resolved)
       nisabInfo,
       userNotes: snapshot.userNotes
     };


### PR DESCRIPTION
## Muharram 1448 audit — TODO triage (Stream E)

`AnnualSummaryService.generateSummary()` had two `TODO(#314): Add methodology to YearlySnapshot schema` comments. **The schema already has the field** — `methodologyUsed` was added alongside the hawl-tracking fields. The service was reading a *nonexistent* `.methodology` field through `(snapshot as any)` and always falling back to `'standard'`.

**Verified empirically** against the generated Prisma client + test DB:
- `select: { methodologyUsed: true }` → OK, returns `"Standard"`
- `select: { methodology: true }` → unknown-field error (field does not exist)

So the old code was masking the real methodology (e.g. a Hanafi snapshot's annual summary reported "standard").

## Changes
- `nisabInfo.methodology` ← `snapshot.methodologyUsed`
- `summaryData.methodologyUsed` ← `snapshot.methodologyUsed` (any-casts removed)
- stale TODOs removed

## Verification
- [x] `tsc --noEmit`: clean
- [x] Server suite: **474/474** (incl. all 28 AnnualSummaryService tests)

Part of the audit plan: `docs/plans/2026-09-11-muharram-1448-audit-v0160-plan.md`