### PR TITLE
fix(ux+currency): #310 round 5 — liabilities total, AssetList resolver + states

### DIFF
--- a/client/src/components/assets/AssetList.tsx
+++ b/client/src/components/assets/AssetList.tsx
@@ -31,7 +31,7 @@ import { normalizeAssetsToCurrency, FxRates } from '../../utils/currencyNormaliz
 
 export const AssetList: React.FC = () => {
   const navigate = useNavigate();
-  const { assets, removeAsset } = useAssetRepository();
+  const { assets, isLoading, error, removeAsset } = useAssetRepository();
   const { privacyMode } = usePrivacy();
   const [viewMode, setViewMode] = useState<'grid' | 'list'>('grid');
 
@@ -47,9 +47,12 @@ export const AssetList: React.FC = () => {
 
   const { settings } = useUserSettingsRepository();
   const methodology = (settings?.preferredMethodology?.toUpperCase() || 'STANDARD') as ZakatMethodology;
-  // Currency resolution (#310): settings repo first, then auth-context profile, then USD.
+  // Currency resolution (#310 round 5): the local RxDB settings store stores
+  // the display currency as `baseCurrency` (there is no `currency` field on
+  // the user_settings schema), so read `baseCurrency` first, then the
+  // auth-context merged settings, then profile, then USD.
   const { user } = useAuth();
-  const userCurrency = (settings as any)?.currency || (user as any)?.settings?.currency || (user as any)?.preferences?.currency || 'USD';
+  const userCurrency = (settings as any)?.baseCurrency || (user as any)?.settings?.currency || (user as any)?.preferences?.currency || 'USD';
   const fxRatesQuery = useFxRates();
   const fxRates = fxRatesQuery?.data?.data?.rates as FxRates | undefined;
 
@@ -146,7 +149,27 @@ export const AssetList: React.FC = () => {
       )}
 
       {/* Assets List/Grid */}
-      {assets.length === 0 ? (
+      {isLoading ? (
+        /* Loading state — prevents the "No assets yet" flash before RxDB resolves */
+        <Card className="p-12 text-center">
+          <div className="flex justify-center py-4" role="status" aria-live="polite">
+            <div className="h-8 w-8 animate-spin rounded-full border-4 border-slate-200 border-t-slate-600"></div>
+          </div>
+          <p className="text-sm text-slate-500 mt-2">Loading your assets…</p>
+        </Card>
+      ) : error ? (
+        /* Error state — honest failure, with a retry path */
+        <Card className="p-8 text-center">
+          <div className="w-16 h-16 bg-red-50 rounded-full flex items-center justify-center mx-auto mb-4">
+            <span className="text-2xl">⚠️</span>
+          </div>
+          <h3 className="text-lg font-medium text-slate-900 mb-2">Couldn't load your assets</h3>
+          <p className="text-slate-500 mb-6">{error.message || 'Something went wrong reading your local data.'}</p>
+          <Button onClick={() => window.location.reload()} variant="outline">
+            Retry
+          </Button>
+        </Card>
+      ) : assets.length === 0 ? (
         <Card className="p-12 text-center">
           <div className="w-16 h-16 bg-slate-100 rounded-full flex items-center justify-center mx-auto mb-4">
             <Plus className="h-8 w-8 text-slate-400" />

--- a/client/src/pages/LiabilitiesPage.tsx
+++ b/client/src/pages/LiabilitiesPage.tsx
@@ -23,6 +23,10 @@ import { Button } from '../components/ui';
 import { Modal } from '../components/ui/Modal';
 import { Liability } from '../types';
 import { useMaskedCurrency } from '../contexts/PrivacyContext';
+import { useAuth } from '../contexts/AuthContext';
+import { useFxRates } from '../services/apiHooks';
+import { sumLiabilitiesInCurrency, FxRates } from '../utils/currencyNormalization';
+import { formatCurrency } from '../utils/formatters';
 
 export const LiabilitiesPage: React.FC = () => {
     const { liabilities, isLoading } = useLiabilityRepository();
@@ -53,8 +57,15 @@ export const LiabilitiesPage: React.FC = () => {
         );
     }
 
-    // Calculate totals
-    const totalLiabilities = liabilities.reduce((sum, l) => sum + l.amount, 0);
+    // Calculate totals — #310 round 5: liabilities may be stored in mixed
+    // currencies; sum through the shared normalizer (same rule as assets),
+    // and show an honest placeholder when FX rates are unavailable instead
+    // of a raw apples+oranges total. Previously this page hardcoded USD.
+    const { user } = useAuth();
+    const userCurrency = (user as any)?.settings?.currency || (user as any)?.preferences?.currency || 'USD';
+    const fxRatesQuery = useFxRates();
+    const fxRates = fxRatesQuery?.data?.data?.rates as FxRates | undefined;
+    const liabilityTotal = sumLiabilitiesInCurrency(liabilities, userCurrency, fxRates);
 
     return (
         <div className="space-y-6">
@@ -79,8 +90,13 @@ export const LiabilitiesPage: React.FC = () => {
                 <div className="bg-white/80 backdrop-blur-sm shadow-sm rounded-xl border border-primary-100/50 p-6 transition-all hover:shadow-md">
                     <dt className="text-sm font-medium text-gray-500 truncate mb-1">Total Liabilities</dt>
                     <dd className="text-4xl font-heading font-bold text-primary-700">
-                        {maskedCurrency(new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(totalLiabilities))}
+                        {liabilityTotal.converted
+                            ? maskedCurrency(formatCurrency(liabilityTotal.total, userCurrency as never))
+                            : '—'}
                     </dd>
+                    {!liabilityTotal.converted && (
+                        <dd className="mt-1 text-xs text-gray-400">Updating exchange rates…</dd>
+                    )}
                 </div>
                 {/* We can add more stats here later like "Deductible Amount" */}
             </div>

--- a/client/src/pages/__tests__/liabilitiesPageCurrency.test.tsx
+++ b/client/src/pages/__tests__/liabilitiesPageCurrency.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2024 ZakApp Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ */
+
+import React from 'react';
+import { render, screen, cleanup } from '@testing-library/react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { PrivacyProvider } from '../../contexts/PrivacyContext';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { LiabilitiesPage } from '../LiabilitiesPage';
+import { sumLiabilitiesInCurrency } from '../../utils/currencyNormalization';
+
+// Regression tests for #310 round 5: LiabilitiesPage previously hardcoded
+// 'USD' in its total (a local Intl.NumberFormat bypassing the user's
+// currency preference) and raw-summed mixed-currency liabilities.
+
+// Mock AuthContext — LiabilitiesPage (and the repo hooks it uses) call useAuth
+vi.mock('../../contexts/AuthContext', () => ({
+    useAuth: () => ({
+        user: {
+            settings: { currency: 'USD' },
+        },
+        updateLocalProfile: vi.fn(),
+    }),
+}));
+
+// Mock the DB + repositories: the page's data comes from RxDB via repo hooks,
+// which need a real initialized database. For this unit test we only need the
+// loading→loaded render contract, so stub the repository hooks directly.
+vi.mock('../../hooks/useLiabilityRepository', () => ({
+    useLiabilityRepository: () => ({
+        liabilities: [],
+        isLoading: false,
+        error: null,
+        addLiability: vi.fn(),
+        updateLiability: vi.fn(),
+        removeLiability: vi.fn(),
+    }),
+}));
+
+const renderPage = () =>
+  render(
+    <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+      <PrivacyProvider>
+        <MemoryRouter>
+          <LiabilitiesPage />
+        </MemoryRouter>
+      </PrivacyProvider>
+    </QueryClientProvider>
+  );
+
+afterEach(cleanup);
+
+describe('LiabilitiesPage currency handling (#310 round 5)', () => {
+  it('sumLiabilitiesInCurrency honors the display currency for a single currency', () => {
+    const r = sumLiabilitiesInCurrency(
+      [
+        { amount: 100, currency: 'USD' },
+        { amount: 250, currency: 'USD' },
+      ],
+      'USD',
+      {}
+    );
+    expect(r.total).toBe(350);
+    expect(r.converted).toBe(true);
+  });
+
+  it('flags mixed-currency sums as unconverted when no FX rates exist', () => {
+    const r = sumLiabilitiesInCurrency(
+      [
+        { amount: 100, currency: 'USD' },
+        { amount: 1_000_000, currency: 'IDR' },
+      ],
+      'USD',
+      undefined
+    );
+    // The total is not trustworthy — callers must show the placeholder.
+    expect(r.converted).toBe(false);
+    expect(r.mixed).toBe(true);
+  });
+
+  it('converts a foreign-currency liability when rates are provided', () => {
+    // USD-based rates: 1 USD = 15,750 IDR (matches the /api/zakat/fx-rates scale)
+    const rates = { USD: 1, IDR: 15_750 };
+    const r = sumLiabilitiesInCurrency([{ amount: 15_750_000, currency: 'IDR' }], 'USD', rates);
+    expect(r.total).toBeCloseTo(1000, 5);
+    expect(r.converted).toBe(true);
+  });
+
+  it('renders the page content once data resolves (smoke)', async () => {
+    // Repositories are stubbed to isLoading:false with an empty list, so the
+    // page should render its full chrome: header, summary card, add button.
+    // The currency contract itself is asserted by the sumLiabilities tests.
+    renderPage();
+    expect(screen.getByText('Total Liabilities')).toBeInTheDocument();
+    expect(screen.getByText(/Add Liability/)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Muharram 1448 audit — Stream E (UX polish, inspection-found gaps)

### 1. LiabilitiesPage hardcoded-USD total (last display-side #310 survivor)
The summary card used a local `Intl.NumberFormat(..., { currency: 'USD' })` — ignoring the user's currency preference and raw-summing mixed-currency liabilities. Now: `sumLiabilitiesInCurrency` + shared `formatCurrency` + the honest placeholder when FX rates are unavailable (converted-flag contract from round 4).

### 2. AssetList currency resolver bug
Read `(settings as any)?.currency`, but the RxDB `user_settings` schema stores the display currency as **`baseCurrency`** — the first link of the resolver chain always missed. Fixed to read `baseCurrency` first.

### 3. AssetList loading/error states
Rendered the "No assets yet" empty state **while RxDB was still loading** (false-empty flash) and had no error UI. Now: aria-live spinner → honest error card with retry → empty state only after load settles.

## Tests
- New `liabilitiesPageCurrency.test.tsx`: 4 tests (single-currency sum, mixed-currency `converted:false` flag, IDR conversion at the `/api/zakat/fx-rates` scale, render smoke)
- Client: **509 passed / 1 documented skip** (was 505)
- `tsc --noEmit` clean; build + PWA precache green

Part of `docs/plans/2026-09-11-muharram-1448-audit-v0160-plan.md` (Stream E).