### PR TITLE
feat(dark-mode): gray-* retrofit — fix dark-on-dark rendering in dark mode

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -117,6 +117,74 @@
   background-color: hsl(217 33% 17%);
 }
 
+/* ── Gray retrofit (Muharram 1448 audit, dark-mode pilot) ────────────────────
+   The audit found 2,770 gray-* utility usages and ZERO .dark overrides for
+   them — gray-based components rendered dark-on-dark / light-on-light in dark
+   mode. Mirrors the slate retrofit above; the 8 components that already use
+   their own dark:gray variants keep working because these un-layered rules
+   apply visually-correct dark values at the same cascade position.
+   Mapping: gray-N (light) → navy-teal family equivalents of the slate rules. */
+
+/* Backgrounds */
+.dark .bg-gray-50 { background-color: hsl(217 33% 14%); }
+.dark .bg-gray-100 { background-color: hsl(217 33% 17%); }
+.dark .bg-gray-200 { background-color: hsl(217 27% 22%); }
+.dark .bg-gray-300 { background-color: hsl(217 27% 26%); }
+.dark .bg-gray-400 { background-color: hsl(215 20% 45%); }
+.dark .bg-gray-500 { background-color: hsl(215 20% 55%); }
+.dark .bg-gray-600 { background-color: hsl(215 25% 40%); }
+.dark .bg-gray-700 { background-color: hsl(217 27% 26%); }
+.dark .bg-gray-800 { background-color: hsl(217 30% 20%); }
+.dark .bg-gray-900 { background-color: hsl(222 30% 14%); }
+
+/* Text */
+.dark .text-gray-900 { color: hsl(210 40% 96%); }
+.dark .text-gray-800 { color: hsl(214 32% 91%); }
+.dark .text-gray-700 { color: hsl(215 25% 83%); }
+.dark .text-gray-600 { color: hsl(215 20% 74%); }
+.dark .text-gray-500 { color: hsl(215 20% 65%); }
+.dark .text-gray-400 { color: hsl(215 16% 55%); }
+.dark .text-gray-300 { color: hsl(215 16% 45%); }
+.dark .text-gray-200 { color: hsl(215 16% 35%); }
+.dark .text-gray-100 { color: hsl(215 16% 28%); }
+/* text-gray-100/200 pair with DARK backgrounds in light mode (tooltips,
+   dark chips) — keep them light in dark mode instead of dimming them */
+.dark .text-gray-100,
+.dark .text-gray-200 { color: hsl(210 40% 96%); }
+
+/* Borders */
+.dark .border-gray-50 { border-color: hsl(217 27% 18%); }
+.dark .border-gray-100 { border-color: hsl(217 27% 18%); }
+.dark .border-gray-200 { border-color: hsl(var(--border)); }
+.dark .border-gray-300 { border-color: hsl(217 27% 28%); }
+.dark .border-gray-400 { border-color: hsl(215 16% 35%); }
+.dark .border-gray-600 { border-color: hsl(215 20% 40%); }
+.dark .border-gray-700 { border-color: hsl(215 25% 45%); }
+
+/* Dividers */
+.dark .divide-gray-100 > :not([hidden]) ~ :not([hidden]) { border-color: hsl(217 27% 18%); }
+.dark .divide-gray-200 > :not([hidden]) ~ :not([hidden]) { border-color: hsl(217 27% 22%); }
+.dark .divide-gray-700 > :not([hidden]) ~ :not([hidden]) { border-color: hsl(215 25% 35%); }
+
+/* Hover states (same un-layered position, :hover-specific) */
+.dark .hover\:bg-gray-50:hover { background-color: hsl(217 33% 14%); }
+.dark .hover\:bg-gray-100:hover { background-color: hsl(217 33% 17%); }
+.dark .hover\:bg-gray-200:hover { background-color: hsl(217 27% 22%); }
+.dark .hover\:bg-gray-300:hover { background-color: hsl(217 27% 26%); }
+.dark .hover\:bg-gray-600:hover { background-color: hsl(215 25% 45%); }
+.dark .hover\:bg-gray-700:hover { background-color: hsl(217 27% 30%); }
+.dark .hover\:bg-gray-800:hover { background-color: hsl(217 30% 24%); }
+.dark .hover\:text-gray-900:hover { color: hsl(210 40% 96%); }
+.dark .hover\:text-gray-800:hover { color: hsl(214 32% 91%); }
+.dark .hover\:text-gray-700:hover { color: hsl(215 25% 83%); }
+.dark .hover\:text-gray-600:hover { color: hsl(215 20% 74%); }
+.dark .hover\:text-gray-500:hover { color: hsl(215 20% 65%); }
+.dark .hover\:text-gray-400:hover { color: hsl(215 16% 55%); }
+.dark .hover\:text-gray-300:hover { color: hsl(215 16% 45%); }
+.dark .hover\:text-gray-200:hover { color: hsl(215 16% 35%); }
+.dark .hover\:border-gray-300:hover { border-color: hsl(217 27% 28%); }
+.dark .hover\:border-gray-400:hover { border-color: hsl(215 16% 35%); }
+
 @layer components {
 
   /* Glassmorphism Classes */


### PR DESCRIPTION
## Muharram 1448 audit — dark-mode pilot (Stream E)

**Bug found by audit:** the v0.14.0 dark-mode retrofit (`index.css`) covered `slate-*` + `bg-white` but had **zero `.dark` overrides for `gray-*`** — while the codebase uses **2,770 gray-\* utility classes**. Every gray-based surface (Nisab cards, payment history, forms, History page, AssetDetails, admin) rendered dark-on-dark in dark mode.

## Fix — extend the established retrofit pattern
- Gray rules for: `bg-gray-50–900`, `text-gray-100–900`, `border-gray-*`, `divide-gray-*`, and all 17 `hover:` combos actually used in the codebase
- Navy-teal dark values mirroring the existing slate mapping; `text-gray-100/200` intentionally stay light (they're light-on-dark tooltips/chips in light mode)
- **Zero component churn** — CSS only; light mode pixel-identical (all rules `.dark`-scoped)

## Cascade verification (done in the compiled bundle, not assumed)
Tailwind 3.4 compiles `dark:*` variants as `.dark\:bg-gray-800:is(.dark *)` and emits them **after** the retrofits with equal specificity — so:
- Components that explicitly author `dark:bg-gray-*` (8 files: CalculationHistory, CalculationBreakdown, MethodologyCard, CalendarSelector…) **keep their authored values** — no conflict
- Retrofills apply only where no explicit `dark:` variant exists — exactly the gap

## Verification
- [x] `npm run build`: green; compiled CSS contains all new rules (checked programmatically)
- [x] Full client suite: **509 passed / 1 documented skip** (incl. useTheme + a11y suites)
- [x] CSS payload +2.7KB (119KB total)
- [x] Light mode untouched

Plan: `docs/plans/2026-09-11-muharram-1448-audit-v0160-plan.md`