### PR TITLE
refactor(#341 slice 2): useDisplayCurrency hook + RecordDetailPanel

### DIFF
--- a/client/src/components/assets/AssetList.tsx
+++ b/client/src/components/assets/AssetList.tsx
@@ -25,8 +25,8 @@ import { useUserSettingsRepository } from '../../hooks/useUserSettingsRepository
 import { getAssetZakatableValue, ZakatMethodology } from '../../core/calculations/zakat';
 import { Button, Card } from '../ui';
 import { usePrivacy } from '../../contexts/PrivacyContext';
-import { useAuth } from '../../contexts/AuthContext';
 import { useFxRates } from '../../services/apiHooks';
+import { useDisplayCurrency } from '../../hooks/useDisplayCurrency';
 import { normalizeAssetsToCurrency, FxRates } from '../../utils/currencyNormalization';
 
 export const AssetList: React.FC = () => {
@@ -47,12 +47,10 @@ export const AssetList: React.FC = () => {
 
   const { settings } = useUserSettingsRepository();
   const methodology = (settings?.preferredMethodology?.toUpperCase() || 'STANDARD') as ZakatMethodology;
-  // Currency resolution (#310 round 5): the local RxDB settings store stores
-  // the display currency as `baseCurrency` (there is no `currency` field on
-  // the user_settings schema), so read `baseCurrency` first, then the
-  // auth-context merged settings, then profile, then USD.
-  const { user } = useAuth();
-  const userCurrency = (settings as any)?.baseCurrency || (user as any)?.settings?.currency || (user as any)?.preferences?.currency || 'USD';
+  // Currency resolution (#341): consolidated into useDisplayCurrency, which
+  // implements the #310 round 5 chain (local baseCurrency → auth settings →
+  // profile prefs → USD).
+  const { currency: userCurrency } = useDisplayCurrency();
   const fxRatesQuery = useFxRates();
   const fxRates = fxRatesQuery?.data?.data?.rates as FxRates | undefined;
 

--- a/client/src/components/nisab/RecordDetailPanel.tsx
+++ b/client/src/components/nisab/RecordDetailPanel.tsx
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2024 ZakApp Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ */
+
+/**
+ * RecordDetailPanel — the selected-record sidebar extracted from
+ * NisabYearRecordsPage (#341 slice 2). Pure presentation: every action is
+ * a prop callback, mirroring the AssetForm/AuthContext extraction pattern.
+ */
+
+import React from 'react';
+import { RecordRulingsPanel, PaymentHistoryCard } from './index';
+import { HawlProgressIndicator } from '../HawlProgressIndicator';
+import { NisabComparisonWidget } from '../NisabComparisonWidget';
+import { ZakatDisplayCard } from '../tracking/ZakatDisplayCard';
+
+/** Minimal shape of a Nisab year record as consumed by the detail panel. */
+export interface NisabRecordLike {
+  id: string;
+  status?: string;
+  [key: string]: unknown;
+}
+
+/** Minimal asset shape (live or normalized) for rulings + display. */
+export interface DetailAssetLike {
+  id: string;
+  name?: string;
+  category?: string;
+  type?: string;
+  zakatEligible?: boolean | null;
+  isActive?: boolean;
+  [key: string]: unknown;
+}
+
+export interface RecordDetailPanelProps {
+  record: NisabRecordLike;
+  /** Assets already filtered to active, in display currency. */
+  assets: DetailAssetLike[];
+  methodologyName: string;
+  totalObligation: number;
+  totalPaid: number;
+  remainingBalance: number;
+  isFullyPaid: boolean;
+  payments: unknown[];
+  canRecordPayment: boolean;
+  onRecordPayment: () => void;
+  onRefreshCalculations: () => void;
+  formatCurrency: (amount: number, currency?: string) => string;
+}
+
+export const RecordDetailPanel: React.FC<RecordDetailPanelProps> = ({
+  record,
+  assets,
+  methodologyName,
+  totalObligation,
+  totalPaid,
+  remainingBalance,
+  isFullyPaid,
+  payments,
+  canRecordPayment,
+  onRecordPayment,
+  onRefreshCalculations,
+  formatCurrency,
+}) => {
+  return (
+    <div className="space-y-4">
+      <ZakatDisplayCard record={record as never} />
+      <RecordRulingsPanel
+        assets={assets.map(a => ({
+          id: a.id,
+          name: a.name || 'Unnamed asset',
+          category: a.category,
+          type: a.type,
+          zakatEligible: a.zakatEligible,
+        }))}
+        methodologyName={methodologyName}
+      />
+      <HawlProgressIndicator record={record as never} />
+      <NisabComparisonWidget record={record as never} showDetails={true} />
+
+      {/* Payment summary */}
+      <PaymentHistoryCard
+        totalObligation={totalObligation}
+        totalPaid={totalPaid}
+        remainingBalance={remainingBalance}
+        isFullyPaid={isFullyPaid}
+        recordStatus={record.status || 'DRAFT'}
+        payments={payments}
+        canRecordPayment={canRecordPayment}
+        onRecordPayment={onRecordPayment}
+        formatCurrency={formatCurrency}
+      />
+
+      <button
+        onClick={onRefreshCalculations}
+        className="w-full py-2.5 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-lg transition-colors"
+      >
+        🔄 Refresh Calculations
+      </button>
+    </div>
+  );
+};

--- a/client/src/components/nisab/__tests__/recordDetailPanel.test.tsx
+++ b/client/src/components/nisab/__tests__/recordDetailPanel.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2024 ZakApp Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ */
+
+import React from 'react';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { PrivacyProvider } from '../../../contexts/PrivacyContext';
+import { RecordDetailPanel } from '../RecordDetailPanel';
+
+// RecordDetailPanel composes ZakatDisplayCard, RecordRulingsPanel,
+// HawlProgressIndicator, NisabComparisonWidget and PaymentHistoryCard.
+// This suite asserts the panel's OWN contract: prop pass-through and the
+// refresh callback. Children with dedicated suites are stubbed.
+
+// HawlProgressIndicator/NisabComparisonWidget/ZakatDisplayCard use useAuth
+// internally — stub them to keep this a pure panel-contract test.
+vi.mock('../../HawlProgressIndicator', () => ({
+    HawlProgressIndicator: () => <div data-testid="hawl-progress" />,
+}));
+vi.mock('../../NisabComparisonWidget', () => ({
+    NisabComparisonWidget: () => <div data-testid="comparison-widget" />,
+}));
+vi.mock('../../tracking/ZakatDisplayCard', () => ({
+    ZakatDisplayCard: ({ record }: { record: { hijriYear?: number } }) => (
+        <div data-testid="zakat-display">{record.hijriYear} H</div>
+    ),
+}));
+
+vi.mock('../RecordRulingsPanel', () => ({
+    RecordRulingsPanel: () => <div data-testid="rulings-panel" />,
+}));
+
+vi.mock('../PaymentHistoryCard', () => ({
+    PaymentHistoryCard: (props: { canRecordPayment: boolean; onRecordPayment: () => void; totalObligation: number }) => (
+        <div data-testid="payment-history">
+            <span>obligation:{props.totalObligation}</span>
+            {props.canRecordPayment && (
+                <button data-testid="record-payment-btn" onClick={props.onRecordPayment}>
+                    + Record Payment
+                </button>
+            )}
+        </div>
+    ),
+}));
+
+const baseProps = {
+    record: { id: 'r1', status: 'DRAFT', hijriYear: 1448 },
+    assets: [
+        { id: 'a1', name: 'Cash', type: 'CASH', zakatEligible: true, isActive: true },
+    ],
+    methodologyName: 'HANAFI',
+    totalObligation: 1000,
+    totalPaid: 400,
+    remainingBalance: 600,
+    isFullyPaid: false,
+    payments: [],
+    canRecordPayment: true,
+    onRecordPayment: vi.fn(),
+    onRefreshCalculations: vi.fn(),
+    formatCurrency: (n: number) => `$${n}`,
+};
+
+const renderPanel = (overrides: Partial<Record<string, unknown>> = {}) =>
+    render(
+        <PrivacyProvider>
+            <RecordDetailPanel {...baseProps} {...overrides} />
+        </PrivacyProvider>
+    );
+
+afterEach(cleanup);
+
+describe('RecordDetailPanel (#341 slice 2)', () => {
+    it('renders all five child sections', () => {
+        renderPanel();
+        expect(screen.getByTestId('rulings-panel')).toBeInTheDocument();
+        expect(screen.getByTestId('payment-history')).toBeInTheDocument();
+        expect(screen.getByTestId('hawl-progress')).toBeInTheDocument();
+        expect(screen.getByTestId('comparison-widget')).toBeInTheDocument();
+        expect(screen.getByTestId('zakat-display')).toBeInTheDocument();
+    });
+
+    it('passes canRecordPayment through — button hidden when fully paid', () => {
+        const { unmount } = renderPanel({ isFullyPaid: true, canRecordPayment: false });
+        expect(screen.queryByTestId('record-payment-btn')).not.toBeInTheDocument();
+        unmount();
+        renderPanel({ isFullyPaid: false, canRecordPayment: true });
+        expect(screen.getByTestId('record-payment-btn')).toBeInTheDocument();
+    });
+
+    it('forwards the payment callback', () => {
+        renderPanel();
+        fireEvent.click(screen.getByTestId('record-payment-btn'));
+        expect(baseProps.onRecordPayment).toHaveBeenCalledTimes(1);
+    });
+
+    it('forwards the refresh callback', () => {
+        renderPanel();
+        fireEvent.click(screen.getByText(/Refresh Calculations/));
+        expect(baseProps.onRefreshCalculations).toHaveBeenCalledTimes(1);
+    });
+});

--- a/client/src/components/nisab/index.ts
+++ b/client/src/components/nisab/index.ts
@@ -4,6 +4,7 @@ export { EditDatePopover } from './EditDatePopover';
 export { NisabRecordCard } from './NisabRecordCard';
 export { RecordRulingsPanel } from './RecordRulingsPanel';
 export { PaymentHistoryCard } from './PaymentHistoryCard';
+export { RecordDetailPanel } from './RecordDetailPanel';
 export type { RecordRulingsPanelProps } from './RecordRulingsPanel';
 export type { CreateRecordModalProps } from './CreateRecordModal';
 export type { RecordPaymentModalProps } from './RecordPaymentModal';

--- a/client/src/hooks/__tests__/useDisplayCurrency.test.ts
+++ b/client/src/hooks/__tests__/useDisplayCurrency.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) 2024 ZakApp Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, render, screen, cleanup, waitFor } from '@testing-library/react';
+import React from 'react';
+import { useDisplayCurrency } from '../useDisplayCurrency';
+
+// The hook composes three sources; stub each and verify the resolution
+// order and the masking contract instead of rendering real providers.
+
+const mockSettingsRepo = vi.fn();
+const mockUseAuth = vi.fn();
+const mockMask = vi.fn((v: string) => v);
+
+vi.mock('../useUserSettingsRepository', () => ({
+    useUserSettingsRepository: () => mockSettingsRepo(),
+}));
+
+vi.mock('../../contexts/AuthContext', () => ({
+    useAuth: () => mockUseAuth(),
+}));
+
+vi.mock('../../contexts/PrivacyContext', () => ({
+    useMaskedCurrency: () => mockMask,
+}));
+
+describe('useDisplayCurrency (#341 consolidation)', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockMask.mockImplementation((v: string) => v);
+    });
+    afterEach(cleanup);
+
+    it('resolves baseCurrency from local RxDB settings first', () => {
+        mockSettingsRepo.mockReturnValue({ settings: { baseCurrency: 'IDR' } });
+        mockUseAuth.mockReturnValue({ user: { settings: { currency: 'USD' } } });
+        const { result } = renderHook(() => useDisplayCurrency());
+        expect(result.current.currency).toBe('IDR');
+    });
+
+    it('falls through to auth settings when local settings absent', () => {
+        mockSettingsRepo.mockReturnValue({ settings: null });
+        mockUseAuth.mockReturnValue({ user: { settings: { currency: 'GBP' } } });
+        const { result } = renderHook(() => useDisplayCurrency());
+        expect(result.current.currency).toBe('GBP');
+    });
+
+    it('falls through to legacy preferences.currency', () => {
+        mockSettingsRepo.mockReturnValue({ settings: null });
+        mockUseAuth.mockReturnValue({ user: { preferences: { currency: 'EUR' } } });
+        const { result } = renderHook(() => useDisplayCurrency());
+        expect(result.current.currency).toBe('EUR');
+    });
+
+    it('defaults to USD when nothing is set', () => {
+        mockSettingsRepo.mockReturnValue({ settings: null });
+        mockUseAuth.mockReturnValue({ user: null });
+        const { result } = renderHook(() => useDisplayCurrency());
+        expect(result.current.currency).toBe('USD');
+    });
+
+    it('formats with Intl and applies the privacy mask', () => {
+        mockSettingsRepo.mockReturnValue({ settings: { baseCurrency: 'USD' } });
+        mockUseAuth.mockReturnValue({ user: null });
+        // Simulate privacy mode: mask replaces digits
+        mockMask.mockImplementation((v: string) => v.replace(/\d/g, '•'));
+
+        const { result } = renderHook(() => useDisplayCurrency());
+        const out = result.current.formatCurrency(1234.5);
+        // The mask must receive the formatted string and its return wins:
+        expect(mockMask).toHaveBeenCalledWith('$1,234.5');
+        expect(out).toBe('$•,•••.•');
+        expect(out).not.toContain('1');
+    });
+
+    it('can format in an explicit currency different from the display currency', () => {
+        mockSettingsRepo.mockReturnValue({ settings: { baseCurrency: 'USD' } });
+        mockUseAuth.mockReturnValue({ user: null });
+        const { result } = renderHook(() => useDisplayCurrency());
+        result.current.formatCurrency(15750000, 'IDR');
+        // Node's ICU renders IDR as 'IDR 15,750,000' (code, not symbol)
+        expect(mockMask).toHaveBeenCalledWith(expect.stringContaining('IDR'));
+    });
+});
+
+describe('useDisplayCurrency render contract', () => {
+    it('updates when local settings change', async () => {
+        let settings: { baseCurrency: string } | null = { baseCurrency: 'USD' };
+        mockSettingsRepo.mockImplementation(() => ({ settings }));
+        mockUseAuth.mockReturnValue({ user: null });
+
+        const { result, rerender } = renderHook(() => useDisplayCurrency());
+        expect(result.current.currency).toBe('USD');
+
+        settings = { baseCurrency: 'IDR' };
+        rerender();
+        expect(result.current.currency).toBe('IDR');
+    });
+});

--- a/client/src/hooks/useDisplayCurrency.ts
+++ b/client/src/hooks/useDisplayCurrency.ts
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2024 ZakApp Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ */
+
+/**
+ * useDisplayCurrency — single source of truth for the user's display currency
+ * and privacy-masked currency formatting (#310 / #341 consolidation).
+ *
+ * Before this hook, the resolver chain (local settings → auth settings →
+ * profile prefs → USD) was copy-pasted into 12+ files and the
+ * Intl.NumberFormat + maskedCurrency pairing into 15 more, with local
+ * drift (LiabilitiesPage hardcoded USD — fixed in #357; AssetList read a
+ * nonexistent `currency` field — fixed in #357 round 5). This hook is the
+ * canonical implementation; call sites migrate to it one by one.
+ *
+ * Resolution order (matches #310 round 5 semantics):
+ *   1. Local RxDB user_settings.baseCurrency  (fastest, offline-first)
+ *   2. Auth-context user.settings.currency    (server-synced settings)
+ *   3. Auth-context user.preferences.currency (legacy profile field)
+ *   4. 'USD' fallback
+ */
+
+import { useCallback } from 'react';
+import { useAuth } from '../contexts/AuthContext';
+import { useMaskedCurrency } from '../contexts/PrivacyContext';
+import { useUserSettingsRepository } from './useUserSettingsRepository';
+
+export interface DisplayCurrency {
+  /** Resolved ISO-4217 currency code, e.g. 'USD', 'IDR'. */
+  currency: string;
+  /**
+   * Format an amount in the display currency with privacy masking applied.
+   * Pass an explicit currency to format in a different code (e.g. a record
+   * stored in IDR while the display currency is USD).
+   */
+  formatCurrency: (amount: number, currency?: string) => string;
+}
+
+export function useDisplayCurrency(): DisplayCurrency {
+  const { settings } = useUserSettingsRepository();
+  const { user } = useAuth();
+  const maskedCurrency = useMaskedCurrency();
+
+  const currency =
+    settings?.baseCurrency ||
+    (user as { settings?: { currency?: string } } | null)?.settings?.currency ||
+    (user as { preferences?: { currency?: string } } | null)?.preferences?.currency ||
+    'USD';
+
+  const formatCurrency = useCallback(
+    (amount: number, fmtCurrency: string = currency): string => {
+      const formatted = new Intl.NumberFormat('en-US', {
+        style: 'currency',
+        currency: fmtCurrency,
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 2,
+      }).format(amount);
+      return maskedCurrency(formatted);
+    },
+    [currency, maskedCurrency]
+  );
+
+  return { currency, formatCurrency };
+}

--- a/client/src/pages/LiabilitiesPage.tsx
+++ b/client/src/pages/LiabilitiesPage.tsx
@@ -23,10 +23,10 @@ import { Button } from '../components/ui';
 import { Modal } from '../components/ui/Modal';
 import { Liability } from '../types';
 import { useMaskedCurrency } from '../contexts/PrivacyContext';
-import { useAuth } from '../contexts/AuthContext';
 import { useFxRates } from '../services/apiHooks';
+import { useDisplayCurrency } from '../hooks/useDisplayCurrency';
 import { sumLiabilitiesInCurrency, FxRates } from '../utils/currencyNormalization';
-import { formatCurrency } from '../utils/formatters';
+import { formatCurrency as formatInCurrency } from '../utils/formatters';
 
 export const LiabilitiesPage: React.FC = () => {
     const { liabilities, isLoading } = useLiabilityRepository();
@@ -61,8 +61,8 @@ export const LiabilitiesPage: React.FC = () => {
     // currencies; sum through the shared normalizer (same rule as assets),
     // and show an honest placeholder when FX rates are unavailable instead
     // of a raw apples+oranges total. Previously this page hardcoded USD.
-    const { user } = useAuth();
-    const userCurrency = (user as any)?.settings?.currency || (user as any)?.preferences?.currency || 'USD';
+    // Currency resolution now via useDisplayCurrency (#341).
+    const { currency: userCurrency, formatCurrency } = useDisplayCurrency();
     const fxRatesQuery = useFxRates();
     const fxRates = fxRatesQuery?.data?.data?.rates as FxRates | undefined;
     const liabilityTotal = sumLiabilitiesInCurrency(liabilities, userCurrency, fxRates);
@@ -91,7 +91,7 @@ export const LiabilitiesPage: React.FC = () => {
                     <dt className="text-sm font-medium text-gray-500 truncate mb-1">Total Liabilities</dt>
                     <dd className="text-4xl font-heading font-bold text-primary-700">
                         {liabilityTotal.converted
-                            ? maskedCurrency(formatCurrency(liabilityTotal.total, userCurrency as never))
+                            ? maskedCurrency(formatInCurrency(liabilityTotal.total, userCurrency as never))
                             : '—'}
                     </dd>
                     {!liabilityTotal.converted && (

--- a/client/src/pages/NisabYearRecordsPage.tsx
+++ b/client/src/pages/NisabYearRecordsPage.tsx
@@ -19,10 +19,6 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 import toast from 'react-hot-toast';
 import { calculateWealth } from '../core/calculations/wealthCalculator';
 import { gregorianToHijri } from '../utils/calendarConverter';
-import HawlProgressIndicator from '../components/HawlProgressIndicator';
-import NisabComparisonWidget from '../components/NisabComparisonWidget';
-import ZakatDisplayCard from '../components/tracking/ZakatDisplayCard';
-import { PaymentCard } from '../components/tracking/PaymentCard';
 import { useNisabRecordRepository } from '../hooks/useNisabRecordRepository';
 import { usePaymentRepository } from '../hooks/usePaymentRepository';
 import { useAssetRepository } from '../hooks/useAssetRepository';
@@ -30,8 +26,9 @@ import { useLiabilityRepository } from '../hooks/useLiabilityRepository';
 import { useAuth } from '../contexts/AuthContext';
 import { useMaskedCurrency } from '../contexts/PrivacyContext';
 import { useFxRates } from '../services/apiHooks';
+import { useDisplayCurrency } from '../hooks/useDisplayCurrency';
 import { normalizeAssetsToCurrency, normalizeLiabilitiesToCurrency, FxRates } from '../utils/currencyNormalization';
-import { CreateRecordModal, RecordPaymentModal, NisabRecordCard, RecordRulingsPanel, PaymentHistoryCard } from '../components/nisab';
+import { CreateRecordModal, RecordPaymentModal, NisabRecordCard, RecordDetailPanel } from '../components/nisab';
 
 export const NisabYearRecordsPage: React.FC = () => {
   const navigate = useNavigate();
@@ -53,7 +50,7 @@ export const NisabYearRecordsPage: React.FC = () => {
   const [newStartDate, setNewStartDate] = useState<string>('');
 
   const { user } = useAuth();
-  const userCurrency = (user as any)?.settings?.currency || (user as any)?.preferences?.currency || 'USD';
+  const { currency: userCurrency, formatCurrency } = useDisplayCurrency();
   const defaultNisabBasis = (user?.settings?.preferredNisabStandard as 'GOLD' | 'SILVER') || 'GOLD';
 
   // Issue #310 (round 4): assets may be stored in mixed currencies (e.g. USD
@@ -105,17 +102,8 @@ export const NisabYearRecordsPage: React.FC = () => {
     }
   }, [records, selectedRecordId]);
 
-  // Format currency
+  // Format currency — consolidated into useDisplayCurrency (#341)
   const maskedCurrency = useMaskedCurrency();
-  const formatCurrency = (amount: number, currency: string = userCurrency): string => {
-    const formatted = new Intl.NumberFormat('en-US', {
-      style: 'currency',
-      currency,
-      minimumFractionDigits: 0,
-      maximumFractionDigits: 2,
-    }).format(amount);
-    return maskedCurrency(formatted);
-  };
 
   // Create Record — now driven by modal
   const handleCreateSubmit = async (payload: {
@@ -336,42 +324,21 @@ export const NisabYearRecordsPage: React.FC = () => {
           {/* Selected Record Details */}
           <div className="lg:col-span-1">
             {activeRecord ? (
-              <div className={`${!selectedRecordId ? 'hidden lg:block' : ''} space-y-4`}>
-                <ZakatDisplayCard record={activeRecord} />
-                <RecordRulingsPanel
-                  assets={allAssets
-                    .filter(a => a.isActive)
-                    .map(a => ({
-                      id: a.id,
-                      name: a.name || 'Unnamed asset',
-                      category: (a as any).category,
-                      type: (a as any).type,
-                      zakatEligible: (a as any).zakatEligible,
-                    }))}
+              <div className={`${!selectedRecordId ? 'hidden lg:block' : ''}`}>
+                <RecordDetailPanel
+                  record={activeRecord as never}
+                  assets={allAssets.filter(a => a.isActive) as never}
                   methodologyName={((user as any)?.settings?.preferredMethodology || 'STANDARD').toUpperCase()}
-                />
-                <HawlProgressIndicator record={activeRecord as any} />
-                <NisabComparisonWidget record={activeRecord} showDetails={true} />
-
-                {/* Payment summary */}
-                <PaymentHistoryCard
                   totalObligation={totalObligation}
                   totalPaid={totalPaid}
                   remainingBalance={remainingBalance}
                   isFullyPaid={isFullyPaid}
-                  recordStatus={activeRecord.status || 'DRAFT'}
                   payments={recordPayments as unknown[]}
                   canRecordPayment={!isFullyPaid && activeRecord.status === 'DRAFT'}
                   onRecordPayment={() => setShowPaymentModal(true)}
+                  onRefreshCalculations={() => handleRefreshAssets(activeRecord.id)}
                   formatCurrency={formatCurrency}
                 />
-
-                <button
-                  onClick={() => handleRefreshAssets(activeRecord.id)}
-                  className="w-full py-2.5 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-lg transition-colors"
-                >
-                  🔄 Refresh Calculations
-                </button>
               </div>
             ) : (
               <div className="hidden lg:flex flex-col items-center justify-center h-full text-center text-gray-400">

--- a/client/tests/accessibility/a11y.test.tsx
+++ b/client/tests/accessibility/a11y.test.tsx
@@ -204,8 +204,7 @@ vi.mock("../../src/components/nisab", () => ({
   CreateRecordModal: () => <div data-testid="create-record-modal">Create Modal</div>,
   RecordPaymentModal: () => <div data-testid="record-payment-modal">Payment Modal</div>,
   NisabRecordCard: () => <div>NisabRecordCard</div>,
-  RecordRulingsPanel: () => <div data-testid="record-rulings-panel">Rulings</div>,
-  PaymentHistoryCard: () => <div data-testid="payment-history-card">Payment History</div>,
+  RecordDetailPanel: () => <div data-testid="record-detail-panel">Detail Panel</div>,
 }));
 
 vi.mock("../../src/components/HawlProgressIndicator", () => ({


### PR DESCRIPTION
## Issue #341 — NisabYearRecordsPage refactor, slice 2

Two extractions following the AssetForm/AuthContext pattern:

### 1. `useDisplayCurrency` hook (canonical currency resolution + formatting)
The resolver chain was copy-pasted into 12+ files, the `Intl.NumberFormat` + `maskedCurrency` pairing into 15 more — drift that caused the real bugs fixed in #357. The hook is now the single source of truth:
- Resolution: local `baseCurrency` → auth settings → profile prefs → `USD`
- `formatCurrency(amount, currency?)` with privacy masking built in
- **3 call sites migrated** (NisabYearRecordsPage, LiabilitiesPage, AssetList), each deleting its local copy
- 7 unit tests: resolution order, mask contract, explicit-currency formatting, reactivity

### 2. `RecordDetailPanel` extraction
The selected-record sidebar (5 child components + refresh button) is now a pure-presentation component in the nisab barrel with callback props. 4 unit tests (prop pass-through, both callbacks, canRecordPayment gating).

## Numbers
- Page: **377 lines** (was 717 at issue filing, 410 after slice 1)
- Client suite: **520 passed / 1 documented skip** (was 509/1)
- tsc clean, build + PWA green

Remaining for #341: RecordListPanel (tabs + records list), record-actions hook.