### PR TITLE
refactor(#341 slice 3): RecordListPanel — status tabs + records list

### DIFF
--- a/client/src/components/nisab/RecordListPanel.tsx
+++ b/client/src/components/nisab/RecordListPanel.tsx
@@ -1,0 +1,164 @@
+/**
+ * Copyright (c) 2024 ZakApp Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ */
+
+/**
+ * RecordListPanel — status tabs + records list extracted from
+ * NisabYearRecordsPage (#341 slice 3). Pure presentation: state and
+ * record actions arrive as props.
+ */
+
+import React from 'react';
+import { NisabRecordCard } from './index';
+import { NisabRecordLike } from './RecordDetailPanel';
+
+export type RecordStatusFilter = 'all' | 'DRAFT' | 'FINALIZED' | 'UNLOCKED';
+
+export const RECORD_STATUS_FILTERS = ['all', 'DRAFT', 'FINALIZED', 'UNLOCKED'] as const;
+
+const TAB_LABELS: Record<RecordStatusFilter, string> = {
+  all: 'All',
+  DRAFT: 'Active',
+  FINALIZED: 'Finalized',
+  UNLOCKED: 'Unlocked for Editing',
+};
+
+export interface RecordListPanelProps {
+  records: NisabRecordLike[];
+  isLoading: boolean;
+  activeStatusFilter: RecordStatusFilter;
+  onStatusFilterChange: (status: RecordStatusFilter) => void;
+  selectedRecordId: string | null;
+  onSelectRecord: (id: string) => void;
+  onClearSelection: () => void;
+  editingStartDateRecordId: string | null;
+  newStartDate: string;
+  onFinalize: (record: NisabRecordLike) => void;
+  onUnlock: (record: NisabRecordLike) => void;
+  onDelete: (record: NisabRecordLike) => void;
+  onEditDate: (record: NisabRecordLike) => void;
+  onSaveDate: (recordId: string) => void;
+  onCancelDate: () => void;
+  onDateChange: (date: string) => void;
+  onGeneratePdf: (record: NisabRecordLike) => void;
+  onCreateRecord: () => void;
+  formatCurrency: (amount: number, currency?: string) => string;
+  currency: string;
+}
+
+/** Extracted per-record event wiring so the map body stays readable. */
+interface RecordCardHandlers {
+  onSelect: () => void;
+  onFinalize: (e: React.MouseEvent) => void;
+  onUnlock: (e: React.MouseEvent) => void;
+  onDelete: (e: React.MouseEvent) => void;
+  onEditDate: (e: React.MouseEvent) => void;
+  onSaveDate: () => void;
+  onCancelDate: () => void;
+  onDateChange: (date: string) => void;
+  onGeneratePdf: (e: React.MouseEvent) => void;
+}
+
+export const RecordListPanel: React.FC<RecordListPanelProps> = ({
+  records,
+  isLoading,
+  activeStatusFilter,
+  onStatusFilterChange,
+  selectedRecordId,
+  onSelectRecord,
+  onClearSelection,
+  editingStartDateRecordId,
+  newStartDate,
+  onFinalize,
+  onUnlock,
+  onDelete,
+  onEditDate,
+  onSaveDate,
+  onCancelDate,
+  onDateChange,
+  onGeneratePdf,
+  onCreateRecord,
+  formatCurrency,
+  currency,
+}) => {
+  return (
+    <>
+      {/* Back button for mobile when record is selected */}
+      {selectedRecordId && (
+        <button
+          onClick={onClearSelection}
+          className="lg:hidden flex items-center gap-2 text-blue-600 hover:text-blue-700 font-medium"
+        >
+          ← Back to list
+        </button>
+      )}
+
+      {/* Status tabs */}
+      <div className={`flex gap-2 border-b border-gray-200 overflow-x-auto pb-px ${selectedRecordId ? 'hidden lg:flex' : ''}`}>
+        {RECORD_STATUS_FILTERS.map((status) => (
+          <button
+            key={status}
+            onClick={() => onStatusFilterChange(status)}
+            className={`px-3 sm:px-4 py-2 font-medium border-b-2 transition-colors whitespace-nowrap text-sm sm:text-base ${activeStatusFilter === status
+              ? 'border-blue-600 text-blue-600'
+              : 'border-transparent text-gray-600 hover:text-gray-900'
+              }`}
+          >
+            {TAB_LABELS[status]}
+          </button>
+        ))}
+      </div>
+
+      {/* Records list */}
+      {isLoading ? (
+        <div className="flex justify-center py-12">
+          <div className="h-8 w-8 animate-spin rounded-full border-4 border-blue-200 border-t-blue-600"></div>
+        </div>
+      ) : records.length === 0 ? (
+        <div className="rounded-lg border border-gray-200 bg-white p-12 text-center">
+          <p className="text-gray-600">No {activeStatusFilter === 'all' ? '' : activeStatusFilter} records yet</p>
+          <button
+            onClick={onCreateRecord}
+            className="mt-4 text-blue-600 hover:text-blue-700 font-medium"
+          >
+            Create your first record →
+          </button>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {records.map((record) => {
+            const handlers: RecordCardHandlers = {
+              onSelect: () => onSelectRecord(record.id),
+              onFinalize: (e) => { e.stopPropagation(); onFinalize(record); },
+              onUnlock: (e) => { e.stopPropagation(); onUnlock(record); },
+              onDelete: (e) => { e.stopPropagation(); onDelete(record); },
+              onEditDate: (e) => { e.stopPropagation(); onEditDate(record); },
+              onSaveDate: () => onSaveDate(record.id),
+              onCancelDate,
+              onDateChange,
+              onGeneratePdf: (e) => { e.stopPropagation(); onGeneratePdf(record); },
+            };
+            return (
+              <NisabRecordCard
+                key={record.id}
+                record={record as never}
+                isSelected={selectedRecordId === record.id}
+                selectedRecordId={selectedRecordId}
+                showEditPopover={editingStartDateRecordId === record.id}
+                newStartDate={newStartDate}
+                {...handlers}
+                formatCurrency={formatCurrency}
+                currency={currency}
+              />
+            );
+          })}
+        </div>
+      )}
+    </>
+  );
+};

--- a/client/src/components/nisab/__tests__/recordListPanel.test.tsx
+++ b/client/src/components/nisab/__tests__/recordListPanel.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) 2024 ZakApp Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ */
+
+import React from 'react';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { PrivacyProvider } from '../../../contexts/PrivacyContext';
+import { RecordListPanel } from '../RecordListPanel';
+
+// RecordListPanel wraps NisabRecordCard, which needs useAuth + repositories.
+// Stub the card and assert the panel's OWN contract: tabs, loading/empty
+// states, and callback wiring.
+
+vi.mock('../NisabRecordCard', () => ({
+    NisabRecordCard: (props: { record: { id: string; hijriYear?: number }; isSelected: boolean; onSelect: () => void; onFinalize: (e: unknown) => void }) => (
+        <div data-testid={`record-card-${props.record.id}`} data-selected={props.isSelected}>
+            <span>{props.record.hijriYear} H</span>
+            <button data-testid={`select-${props.record.id}`} onClick={props.onSelect}>select</button>
+            <button data-testid={`finalize-${props.record.id}`} onClick={props.onFinalize}>finalize</button>
+        </div>
+    ),
+}));
+
+const record = { id: 'r1', hijriYear: 1448, status: 'DRAFT' };
+
+const baseProps = {
+    records: [record],
+    isLoading: false,
+    activeStatusFilter: 'all' as const,
+    onStatusFilterChange: vi.fn(),
+    selectedRecordId: null as string | null,
+    onSelectRecord: vi.fn(),
+    onClearSelection: vi.fn(),
+    editingStartDateRecordId: null as string | null,
+    newStartDate: '',
+    onFinalize: vi.fn(),
+    onUnlock: vi.fn(),
+    onDelete: vi.fn(),
+    onEditDate: vi.fn(),
+    onSaveDate: vi.fn(),
+    onCancelDate: vi.fn(),
+    onDateChange: vi.fn(),
+    onGeneratePdf: vi.fn(),
+    onCreateRecord: vi.fn(),
+    formatCurrency: (n: number) => `$${n}`,
+    currency: 'USD',
+};
+
+const renderPanel = (overrides: Record<string, unknown> = {}) =>
+    render(
+        <PrivacyProvider>
+            <RecordListPanel {...baseProps} {...overrides} />
+        </PrivacyProvider>
+    );
+
+afterEach(cleanup);
+
+describe('RecordListPanel (#341 slice 3)', () => {
+    it('renders all four status tabs with their labels', () => {
+        renderPanel();
+        expect(screen.getByRole('button', { name: 'All' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Active' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Finalized' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Unlocked for Editing' })).toBeInTheDocument();
+    });
+
+    it('marks the active tab and fires the filter callback', () => {
+        renderPanel();
+        const activeTab = screen.getByRole('button', { name: 'All' });
+        expect(activeTab.className).toContain('border-blue-600');
+        fireEvent.click(screen.getByRole('button', { name: 'Finalized' }));
+        expect(baseProps.onStatusFilterChange).toHaveBeenCalledWith('FINALIZED');
+    });
+
+    it('shows the loading spinner while isLoading', () => {
+        renderPanel({ isLoading: true, records: [] });
+        expect(screen.queryByRole('button', { name: /Create your first record/ })).not.toBeInTheDocument();
+        expect(document.querySelector('.animate-spin')).toBeInTheDocument();
+    });
+
+    it('shows the empty state with a create CTA when no records', () => {
+        renderPanel({ records: [] });
+        expect(screen.getByText(/No.*records yet/)).toBeInTheDocument();
+        fireEvent.click(screen.getByText(/Create your first record/));
+        expect(baseProps.onCreateRecord).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders record cards and wires select/finalize through', () => {
+        renderPanel({ selectedRecordId: 'r1' });
+        const card = screen.getByTestId('record-card-r1');
+        expect(card).toBeInTheDocument();
+        expect(card.getAttribute('data-selected')).toBe('true');
+        fireEvent.click(screen.getByTestId('select-r1'));
+        expect(baseProps.onSelectRecord).toHaveBeenCalledWith('r1');
+        fireEvent.click(screen.getByTestId('finalize-r1'));
+        expect(baseProps.onFinalize).toHaveBeenCalledWith(record);
+    });
+
+    it('shows the mobile back button only when a record is selected', () => {
+        const { unmount } = renderPanel({ selectedRecordId: null });
+        expect(screen.queryByText('← Back to list')).not.toBeInTheDocument();
+        unmount();
+        renderPanel({ selectedRecordId: 'r1' });
+        expect(screen.getByText('← Back to list')).toBeInTheDocument();
+    });
+});

--- a/client/src/components/nisab/index.ts
+++ b/client/src/components/nisab/index.ts
@@ -5,6 +5,8 @@ export { NisabRecordCard } from './NisabRecordCard';
 export { RecordRulingsPanel } from './RecordRulingsPanel';
 export { PaymentHistoryCard } from './PaymentHistoryCard';
 export { RecordDetailPanel } from './RecordDetailPanel';
+export { RecordListPanel } from './RecordListPanel';
+export type { RecordListPanelProps, RecordStatusFilter } from './RecordListPanel';
 export type { RecordRulingsPanelProps } from './RecordRulingsPanel';
 export type { CreateRecordModalProps } from './CreateRecordModal';
 export type { RecordPaymentModalProps } from './RecordPaymentModal';

--- a/client/src/pages/NisabYearRecordsPage.tsx
+++ b/client/src/pages/NisabYearRecordsPage.tsx
@@ -28,7 +28,7 @@ import { useMaskedCurrency } from '../contexts/PrivacyContext';
 import { useFxRates } from '../services/apiHooks';
 import { useDisplayCurrency } from '../hooks/useDisplayCurrency';
 import { normalizeAssetsToCurrency, normalizeLiabilitiesToCurrency, FxRates } from '../utils/currencyNormalization';
-import { CreateRecordModal, RecordPaymentModal, NisabRecordCard, RecordDetailPanel } from '../components/nisab';
+import { CreateRecordModal, RecordPaymentModal, RecordListPanel, RecordDetailPanel } from '../components/nisab';
 
 export const NisabYearRecordsPage: React.FC = () => {
   const navigate = useNavigate();
@@ -240,85 +240,37 @@ export const NisabYearRecordsPage: React.FC = () => {
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 lg:gap-6">
           {/* Main content */}
           <div className="lg:col-span-2 space-y-4 sm:space-y-6">
-            {/* Back button for mobile when record is selected */}
-            {selectedRecordId && (
-              <button
-                onClick={() => setSelectedRecordId(null)}
-                className="lg:hidden flex items-center gap-2 text-blue-600 hover:text-blue-700 font-medium"
-              >
-                ← Back to list
-              </button>
-            )}
-
-            {/* Status tabs */}
-            <div className={`flex gap-2 border-b border-gray-200 overflow-x-auto pb-px ${selectedRecordId ? 'hidden lg:flex' : ''}`}>
-              {(['all', 'DRAFT', 'FINALIZED', 'UNLOCKED'] as const).map((status) => {
-                const tabLabels: Record<string, string> = { all: 'All', DRAFT: 'Active', FINALIZED: 'Finalized', UNLOCKED: 'Unlocked for Editing' };
-                return (
-                  <button
-                    key={status}
-                    onClick={() => {
-                      setActiveStatusFilter(status);
-                      setSelectedRecordId(null);
-                    }}
-                    className={`px-3 sm:px-4 py-2 font-medium border-b-2 transition-colors whitespace-nowrap text-sm sm:text-base ${activeStatusFilter === status
-                      ? 'border-blue-600 text-blue-600'
-                      : 'border-transparent text-gray-600 hover:text-gray-900'
-                      }`}
-                  >
-                    {tabLabels[status] || status}
-                  </button>
-                );
-              })}
-            </div>
-
-            {/* Records list */}
-            {isLoading ? (
-              <div className="flex justify-center py-12">
-                <div className="h-8 w-8 animate-spin rounded-full border-4 border-blue-200 border-t-blue-600"></div>
-              </div>
-            ) : records.length === 0 ? (
-              <div className="rounded-lg border border-gray-200 bg-white p-12 text-center">
-                <p className="text-gray-600">No {activeStatusFilter === 'all' ? '' : activeStatusFilter} records yet</p>
-                <button
-                  onClick={() => setShowCreateModal(true)}
-                  className="mt-4 text-blue-600 hover:text-blue-700 font-medium"
-                >
-                  Create your first record →
-                </button>
-              </div>
-            ) : (
-              <div className="space-y-3">
-                {records.map((record) => (
-                  <NisabRecordCard
-                    key={record.id}
-                    record={record}
-                    isSelected={selectedRecordId === record.id}
-                    selectedRecordId={selectedRecordId}
-                    showEditPopover={editingStartDateRecordId === record.id}
-                    newStartDate={newStartDate}
-                    onSelect={() => setSelectedRecordId(record.id)}
-                    onFinalize={(e) => { e.stopPropagation(); handleFinalize(record); }}
-                    onUnlock={(e) => { e.stopPropagation(); handleUnlock(record); }}
-                    onDelete={(e) => { e.stopPropagation(); handleDelete(record); }}
-                    onEditDate={(e) => { e.stopPropagation(); setEditingStartDateRecordId(record.id); }}
-                    onSaveDate={() => handleEditDate(record.id)}
-                    onCancelDate={() => setEditingStartDateRecordId(null)}
-                    onDateChange={setNewStartDate}
-                    onGeneratePdf={(e) => {
-                      e.stopPropagation();
-                      const totalLiabilities = allLiabilities.reduce((sum, l) => sum + Number(l.amount || 0), 0);
-                      import('../utils/ReportGenerator').then(({ ReportGenerator }) => {
-                        const generator = new ReportGenerator(userCurrency);
-                        generator.generateHawlStatement(record as any, allAssets, 'User', totalLiabilities);
-                      });
-                    }}
-                    formatCurrency={formatCurrency}
-                    currency={userCurrency}
-                  />
-                ))}
-              </div>
-            )}
+            <RecordListPanel
+              records={records as never}
+              isLoading={isLoading}
+              activeStatusFilter={activeStatusFilter}
+              onStatusFilterChange={(status) => {
+                setActiveStatusFilter(status);
+                setSelectedRecordId(null);
+              }}
+              selectedRecordId={selectedRecordId}
+              onSelectRecord={setSelectedRecordId}
+              onClearSelection={() => setSelectedRecordId(null)}
+              editingStartDateRecordId={editingStartDateRecordId}
+              newStartDate={newStartDate}
+              onFinalize={handleFinalize}
+              onUnlock={handleUnlock}
+              onDelete={handleDelete}
+              onEditDate={(record) => setEditingStartDateRecordId(record.id)}
+              onSaveDate={handleEditDate}
+              onCancelDate={() => setEditingStartDateRecordId(null)}
+              onDateChange={setNewStartDate}
+              onGeneratePdf={(record) => {
+                const totalLiabilities = allLiabilities.reduce((sum, l) => sum + Number(l.amount || 0), 0);
+                import('../utils/ReportGenerator').then(({ ReportGenerator }) => {
+                  const generator = new ReportGenerator(userCurrency);
+                  generator.generateHawlStatement(record as any, allAssets, 'User', totalLiabilities);
+                });
+              }}
+              onCreateRecord={() => setShowCreateModal(true)}
+              formatCurrency={formatCurrency}
+              currency={userCurrency}
+            />
           </div>
 
           {/* Selected Record Details */}

--- a/client/tests/accessibility/a11y.test.tsx
+++ b/client/tests/accessibility/a11y.test.tsx
@@ -205,6 +205,7 @@ vi.mock("../../src/components/nisab", () => ({
   RecordPaymentModal: () => <div data-testid="record-payment-modal">Payment Modal</div>,
   NisabRecordCard: () => <div>NisabRecordCard</div>,
   RecordDetailPanel: () => <div data-testid="record-detail-panel">Detail Panel</div>,
+  RecordListPanel: () => <div data-testid="record-list-panel">Record List</div>,
 }));
 
 vi.mock("../../src/components/HawlProgressIndicator", () => ({


### PR DESCRIPTION
## Issue #341 — NisabYearRecordsPage refactor, slice 3

Extracts the records-list column into `RecordListPanel` (nisab barrel): mobile back button, status tabs, loading/empty states, and the `NisabRecordCard` list — pure presentation, all actions as callback props. The `stopPropagation` wiring is consolidated into one `RecordCardHandlers` object. `RECORD_STATUS_FILTERS` + tab labels exported for reuse.

## Numbers
- Page: **329 lines** (717 at issue filing → 410 → 377 → 329)
- 6 unit tests (tabs, styling, states, callback wiring, back button)
- Client suite: **526 passed / 1 documented skip**
- tsc clean, build green

Remaining for #341: record-action handlers → `useNisabRecordActions` hook.