### PR TITLE
refactor(#341 slice 4): useNisabRecordActions — record mutations hook (completes #341)

### DIFF
--- a/client/src/hooks/__tests__/useNisabRecordActions.test.ts
+++ b/client/src/hooks/__tests__/useNisabRecordActions.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Copyright (c) 2024 ZakApp Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useNisabRecordActions } from '../useNisabRecordActions';
+
+// Pure hook test: stub the repository callbacks and verify each action's
+// contract — repository calls, payload shaping, toast routing, and the
+// injected page-level side-effect callbacks.
+
+vi.mock('react-hot-toast', () => ({
+    default: { success: vi.fn(), error: vi.fn() },
+}));
+
+import toast from 'react-hot-toast';
+
+const baseOptions = () => ({
+    addRecord: vi.fn().mockResolvedValue({}),
+    updateRecord: vi.fn().mockResolvedValue({}),
+    removeRecord: vi.fn().mockResolvedValue({}),
+    normalizedAssets: [{ id: 'a1', value: 1000 }] as never,
+    normalizedLiabilities: [{ id: 'l1', amount: 100 }] as never,
+    userCurrency: 'USD',
+    userMethodology: 'HANAFI',
+    onCreated: vi.fn(),
+    onDeleted: vi.fn(),
+    onDateSaved: vi.fn(),
+});
+
+const payload = {
+    assetIds: ['a1'],
+    liabilityIds: ['l1'],
+    basis: 'GOLD' as const,
+    date: new Date('2026-09-01T00:00:00.000Z'),
+    nisabAmount: 6000,
+};
+
+beforeEach(() => {
+    vi.clearAllMocks();
+});
+
+describe('useNisabRecordActions (#341 slice 4)', () => {
+    it('createRecord adds a DRAFT record shaped from the payload', async () => {
+        const opts = baseOptions();
+        const { result } = renderHook(() => useNisabRecordActions(opts));
+
+        const ok = await act(() => result.current.createRecord(payload));
+        expect(ok).toBe(true);
+        expect(opts.addRecord).toHaveBeenCalledTimes(1);
+        const arg = opts.addRecord.mock.calls[0][0];
+        expect(arg.status).toBe('DRAFT');
+        expect(arg.currency).toBe('USD');
+        expect(arg.nisabBasis).toBe('GOLD');
+        expect(arg.nisabThresholdAtStart).toBe('6000');
+        expect(new Date(arg.hawlCompletionDate).getTime() - new Date(arg.hawlStartDate).getTime())
+            .toBe(354 * 24 * 60 * 60 * 1000);
+        expect(opts.onCreated).toHaveBeenCalledTimes(1);
+        expect(toast.success).toHaveBeenCalledWith('Nisab Year Record created');
+    });
+
+    it('createRecord returns false and toasts error on repository failure', async () => {
+        const opts = baseOptions();
+        opts.addRecord = vi.fn().mockRejectedValue(new Error('db locked'));
+        const { result } = renderHook(() => useNisabRecordActions(opts));
+        const ok = await act(() => result.current.createRecord(payload));
+        expect(ok).toBe(false);
+        expect(toast.error).toHaveBeenCalledWith('db locked');
+        expect(opts.onCreated).not.toHaveBeenCalled();
+    });
+
+    it('createRecord gives zero zakat below the nisab threshold', async () => {
+        const opts = baseOptions();
+        opts.normalizedAssets = [{ id: 'a1', value: 100 }] as never; // below 6000
+        const { result } = renderHook(() => useNisabRecordActions(opts));
+        await act(() => result.current.createRecord(payload));
+        expect(opts.addRecord.mock.calls[0][0].zakatAmount).toBe(0);
+    });
+
+    it('refreshCalculations recalculates and updates the record', async () => {
+        const opts = baseOptions();
+        const { result } = renderHook(() => useNisabRecordActions(opts));
+        await act(() => result.current.refreshCalculations('r1'));
+        expect(opts.updateRecord).toHaveBeenCalledWith('r1', expect.objectContaining({
+            zakatAmount: expect.any(Number),
+        }));
+        expect(toast.success).toHaveBeenCalledWith('Assets refreshed and calculations updated');
+    });
+
+    it('finalizeRecord confirms, then updates status to FINALIZED', async () => {
+        const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+        const opts = baseOptions();
+        const { result } = renderHook(() => useNisabRecordActions(opts));
+        await act(() => result.current.finalizeRecord({ id: 'r1' }));
+        expect(opts.updateRecord).toHaveBeenCalledWith('r1', { status: 'FINALIZED' });
+        confirmSpy.mockRestore();
+    });
+
+    it('finalizeRecord does nothing when the user cancels', async () => {
+        const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+        const opts = baseOptions();
+        const { result } = renderHook(() => useNisabRecordActions(opts));
+        await act(() => result.current.finalizeRecord({ id: 'r1' }));
+        expect(opts.updateRecord).not.toHaveBeenCalled();
+        confirmSpy.mockRestore();
+    });
+
+    it('deleteRecord confirms, removes, and fires onDeleted with the id', async () => {
+        const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+        const opts = baseOptions();
+        const { result } = renderHook(() => useNisabRecordActions(opts));
+        await act(() => result.current.deleteRecord({ id: 'r9' }));
+        expect(opts.removeRecord).toHaveBeenCalledWith('r9');
+        expect(opts.onDeleted).toHaveBeenCalledWith('r9');
+        confirmSpy.mockRestore();
+    });
+
+    it('saveStartDate persists start + 354-day completion + hijri year, and fires onDateSaved', async () => {
+        const opts = baseOptions();
+        const { result } = renderHook(() => useNisabRecordActions(opts));
+        await act(() => result.current.saveStartDate('r1', '2026-09-01T00:00:00.000Z'));
+        const patch = opts.updateRecord.mock.calls[0][1];
+        expect(new Date(patch.hawlCompletionDate).getTime() - new Date(patch.hawlStartDate).getTime())
+            .toBe(354 * 24 * 60 * 60 * 1000);
+        expect(patch.hijriYear).toBeTypeOf('number');
+        expect(opts.onDateSaved).toHaveBeenCalledTimes(1);
+        expect(toast.success).toHaveBeenCalledWith('Date updated');
+    });
+
+    it('saveStartDate is a no-op without a date', async () => {
+        const opts = baseOptions();
+        const { result } = renderHook(() => useNisabRecordActions(opts));
+        await act(() => result.current.saveStartDate('r1', ''));
+        expect(opts.updateRecord).not.toHaveBeenCalled();
+    });
+});

--- a/client/src/hooks/useNisabRecordActions.ts
+++ b/client/src/hooks/useNisabRecordActions.ts
@@ -1,0 +1,167 @@
+/**
+ * Copyright (c) 2024 ZakApp Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ */
+
+/**
+ * useNisabRecordActions — record mutation handlers extracted from
+ * NisabYearRecordsPage (#341 slice 4). Encapsulates create / refresh /
+ * finalize / unlock / delete / edit-date against the local RxDB
+ * repository, with toast feedback. Navigation and UI state that belong to
+ * the page (closing modals, clearing selection) are expressed as
+ * injected callbacks so the hook stays page-agnostic.
+ */
+
+import { useCallback } from 'react';
+import toast from 'react-hot-toast';
+import { calculateWealth } from '../core/calculations/wealthCalculator';
+import { gregorianToHijri } from '../utils/calendarConverter';
+
+export interface CreateRecordPayload {
+  assetIds: string[];
+  liabilityIds: string[];
+  basis: 'GOLD' | 'SILVER';
+  date: Date;
+  nisabAmount: number;
+}
+
+/** Normalized (display-currency) asset/liability rows for calculation. */
+export type WealthRow = Record<string, unknown> & { id: string };
+
+export interface UseNisabRecordActionsOptions {
+  addRecord: (record: Record<string, unknown>) => Promise<unknown>;
+  updateRecord: (id: string, patch: Record<string, unknown>) => Promise<unknown>;
+  removeRecord: (id: string) => Promise<unknown>;
+  /** Normalized assets/liabilities in the display currency (#310 round 4). */
+  normalizedAssets: WealthRow[];
+  normalizedLiabilities: WealthRow[];
+  userCurrency: string;
+  userMethodology: string;
+  /** Page-level side effects invoked after successful mutations. */
+  onCreated?: () => void;
+  onDeleted?: (recordId: string) => void;
+  onDateSaved?: () => void;
+}
+
+const HAWL_MS = 354 * 24 * 60 * 60 * 1000;
+
+export function useNisabRecordActions(options: UseNisabRecordActionsOptions) {
+  const {
+    addRecord,
+    updateRecord,
+    removeRecord,
+    normalizedAssets,
+    normalizedLiabilities,
+    userCurrency,
+    userMethodology,
+    onCreated,
+    onDeleted,
+    onDateSaved,
+  } = options;
+
+  /** Create a record from the modal payload. Returns true on success. */
+  const createRecord = useCallback(async (payload: CreateRecordPayload): Promise<boolean> => {
+    const { assetIds, liabilityIds, basis, date, nisabAmount: threshold } = payload;
+    try {
+      const selectedAssets = normalizedAssets.filter(a => assetIds.includes(a.id));
+      const selectedLiabilities = normalizedLiabilities.filter(l => liabilityIds.includes(l.id));
+
+      const { totalWealth, netZakatableWealth } = calculateWealth(
+        selectedAssets as never, selectedLiabilities as never, new Date(), userMethodology as never
+      );
+      const zakatAmount = netZakatableWealth >= threshold ? netZakatableWealth * 0.025 : 0;
+
+      const completionDate = new Date(date.getTime() + HAWL_MS);
+      const startHijri = gregorianToHijri(date);
+
+      await addRecord({
+        hawlStartDate: date.toISOString(),
+        hawlCompletionDate: completionDate.toISOString(),
+        hijriYear: startHijri.hy,
+        nisabBasis: basis,
+        totalWealth,
+        zakatableWealth: netZakatableWealth,
+        zakatAmount,
+        nisabThresholdAtStart: threshold.toString(),
+        currency: userCurrency,
+        status: 'DRAFT',
+      });
+
+      toast.success('Nisab Year Record created');
+      onCreated?.();
+      return true;
+    } catch (err) {
+      console.error(err);
+      const msg = err instanceof Error ? err.message : 'Failed to create record';
+      toast.error(msg);
+      return false;
+    }
+  }, [normalizedAssets, normalizedLiabilities, userMethodology, userCurrency, addRecord, onCreated]);
+
+  /** Recalculate a record's wealth from the current (normalized) assets. */
+  const refreshCalculations = useCallback(async (recordId: string): Promise<void> => {
+    try {
+      const { totalWealth, netZakatableWealth } = calculateWealth(
+        normalizedAssets as never, normalizedLiabilities as never, new Date(), userMethodology as never
+      );
+      await updateRecord(recordId, {
+        totalWealth,
+        zakatableWealth: netZakatableWealth,
+        zakatAmount: netZakatableWealth * 0.025,
+      });
+      toast.success('Assets refreshed and calculations updated');
+    } catch (error) {
+      console.error('Failed to refresh assets:', error);
+      toast.error('Failed to update calculations');
+    }
+  }, [normalizedAssets, normalizedLiabilities, userMethodology, updateRecord]);
+
+  const finalizeRecord = useCallback(async (record: { id: string }): Promise<void> => {
+    if (window.confirm('Are you sure you want to finalize this record? This will lock it from edits.')) {
+      await updateRecord(record.id, { status: 'FINALIZED' });
+      toast.success('Record finalized');
+    }
+  }, [updateRecord]);
+
+  const unlockRecord = useCallback(async (record: { id: string }): Promise<void> => {
+    await updateRecord(record.id, { status: 'UNLOCKED' });
+    toast.success('Record unlocked');
+  }, [updateRecord]);
+
+  const deleteRecord = useCallback(async (record: { id: string }): Promise<void> => {
+    if (window.confirm('Delete this record? This cannot be undone.')) {
+      await removeRecord(record.id);
+      onDeleted?.(record.id);
+      toast.success('Record deleted');
+    }
+  }, [removeRecord, onDeleted]);
+
+  /** Persist a new hawl start date (ISO string) for a record. */
+  const saveStartDate = useCallback(async (recordId: string, startDateIso: string): Promise<void> => {
+    if (!startDateIso) return;
+    const start = new Date(startDateIso);
+    const completion = new Date(start.getTime() + HAWL_MS);
+    const startHijri = gregorianToHijri(start);
+
+    await updateRecord(recordId, {
+      hawlStartDate: start.toISOString(),
+      hawlCompletionDate: completion.toISOString(),
+      hijriYear: startHijri.hy,
+    });
+    onDateSaved?.();
+    toast.success('Date updated');
+  }, [updateRecord, onDateSaved]);
+
+  return {
+    createRecord,
+    refreshCalculations,
+    finalizeRecord,
+    unlockRecord,
+    deleteRecord,
+    saveStartDate,
+  };
+}

--- a/client/src/pages/NisabYearRecordsPage.tsx
+++ b/client/src/pages/NisabYearRecordsPage.tsx
@@ -16,13 +16,11 @@
 
 import React, { useState, useEffect, useRef } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import toast from 'react-hot-toast';
-import { calculateWealth } from '../core/calculations/wealthCalculator';
-import { gregorianToHijri } from '../utils/calendarConverter';
 import { useNisabRecordRepository } from '../hooks/useNisabRecordRepository';
 import { usePaymentRepository } from '../hooks/usePaymentRepository';
 import { useAssetRepository } from '../hooks/useAssetRepository';
 import { useLiabilityRepository } from '../hooks/useLiabilityRepository';
+import { useNisabRecordActions } from '../hooks/useNisabRecordActions';
 import { useAuth } from '../contexts/AuthContext';
 import { useMaskedCurrency } from '../contexts/PrivacyContext';
 import { useFxRates } from '../services/apiHooks';
@@ -105,108 +103,44 @@ export const NisabYearRecordsPage: React.FC = () => {
   // Format currency — consolidated into useDisplayCurrency (#341)
   const maskedCurrency = useMaskedCurrency();
 
-  // Create Record — now driven by modal
-  const handleCreateSubmit = async (payload: {
-    assetIds: string[];
-    liabilityIds: string[];
-    basis: 'GOLD' | 'SILVER';
-    date: Date;
-    nisabAmount: number;
-  }) => {
-    const { assetIds, liabilityIds, basis, date, nisabAmount: threshold } = payload;
-
-    try {
-      const selectedAssets = normalizedAssets.filter(a => assetIds.includes(a.id));
-      const selectedLiabilities = normalizedLiabilities.filter(l => liabilityIds.includes(l.id));
-
-      const userMethodology = ((user as any)?.settings?.preferredMethodology || 'STANDARD').toUpperCase();
-      const { totalWealth, netZakatableWealth } = calculateWealth(selectedAssets, selectedLiabilities, new Date(), userMethodology as any);
-      const zakatAmount = netZakatableWealth >= threshold ? netZakatableWealth * 0.025 : 0;
-
-      const startDate = date;
-      const completionDate = new Date(startDate.getTime() + 354 * 24 * 60 * 60 * 1000);
-      const startHijri = gregorianToHijri(startDate);
-
-      await addRecord({
-        hawlStartDate: startDate.toISOString(),
-        hawlCompletionDate: completionDate.toISOString(),
-        hijriYear: startHijri.hy,
-        nisabBasis: basis,
-        totalWealth,
-        zakatableWealth: netZakatableWealth,
-        zakatAmount,
-        nisabThresholdAtStart: threshold.toString(),
-        currency: userCurrency,
-        status: 'DRAFT'
-      });
-
-      toast.success('Nisab Year Record created');
+  // Record mutations — extracted into useNisabRecordActions (#341 slice 4)
+  const userMethodology = ((user as any)?.settings?.preferredMethodology || 'STANDARD').toUpperCase();
+  const {
+    createRecord,
+    refreshCalculations,
+    finalizeRecord,
+    unlockRecord,
+    deleteRecord,
+    saveStartDate,
+  } = useNisabRecordActions({
+    addRecord,
+    updateRecord,
+    removeRecord,
+    normalizedAssets: normalizedAssets as never,
+    normalizedLiabilities: normalizedLiabilities as never,
+    userCurrency,
+    userMethodology,
+    onCreated: () => {
       setShowCreateModal(false);
-
       if (allRecords.length === 0) {
         navigate('/dashboard');
       }
-    } catch (err: any) {
-      console.error(err);
-      const msg = err instanceof Error ? err.message : 'Failed to create record';
-      toast.error(msg);
-    }
+    },
+    onDeleted: (recordId) => {
+      if (selectedRecordId === recordId) setSelectedRecordId(null);
+    },
+    onDateSaved: () => setEditingStartDateRecordId(null),
+  });
+
+  const handleCreateSubmit = async (payload: Parameters<typeof createRecord>[0]): Promise<void> => {
+    await createRecord(payload);
   };
+  const handleRefreshAssets = (recordId: string) => refreshCalculations(recordId);
+  const handleFinalize = (record: { id: string }) => finalizeRecord(record);
+  const handleUnlock = (record: { id: string }) => unlockRecord(record);
+  const handleDelete = (record: { id: string }) => deleteRecord(record);
+  const handleEditDate = (recordId: string) => saveStartDate(recordId, newStartDate);
 
-  // Actions
-  const handleRefreshAssets = async (recordId: string) => {
-    try {
-      const userMethodology = ((user as any)?.settings?.preferredMethodology || 'STANDARD').toUpperCase();
-      const { totalWealth, netZakatableWealth } = calculateWealth(normalizedAssets, normalizedLiabilities, new Date(), userMethodology as any);
-      const zakatAmount = netZakatableWealth * 0.025;
-
-      await updateRecord(recordId, {
-        totalWealth,
-        zakatableWealth: netZakatableWealth,
-        zakatAmount,
-      });
-
-      toast.success('Assets refreshed and calculations updated');
-    } catch (error) {
-      console.error('Failed to refresh assets:', error);
-      toast.error('Failed to update calculations');
-    }
-  };
-
-  const handleFinalize = async (record: any) => {
-    if (window.confirm('Are you sure you want to finalize this record? This will lock it from edits.')) {
-      await updateRecord(record.id, { status: 'FINALIZED' });
-      toast.success('Record finalized');
-    }
-  };
-
-  const handleUnlock = async (record: any) => {
-    await updateRecord(record.id, { status: 'UNLOCKED' });
-    toast.success('Record unlocked');
-  };
-
-  const handleDelete = async (record: any) => {
-    if (window.confirm('Delete this record? This cannot be undone.')) {
-      await removeRecord(record.id);
-      if (selectedRecordId === record.id) setSelectedRecordId(null);
-      toast.success('Record deleted');
-    }
-  };
-
-  const handleEditDate = async (recordId: string) => {
-    if (!newStartDate) return;
-    const start = new Date(newStartDate);
-    const completion = new Date(start.getTime() + 354 * 24 * 60 * 60 * 1000);
-    const startHijri = gregorianToHijri(start);
-
-    await updateRecord(recordId, {
-      hawlStartDate: start.toISOString(),
-      hawlCompletionDate: completion.toISOString(),
-      hijriYear: startHijri.hy
-    });
-    setEditingStartDateRecordId(null);
-    toast.success('Date updated');
-  };
 
   // Calculate totals for active record
   const totalPaid = recordPayments.reduce((sum, p) => sum + (Number(p.amount) || 0), 0);


### PR DESCRIPTION
## Issue #341 — NisabYearRecordsPage refactor, final slice

Record mutation handlers (create / refresh / finalize / unlock / delete / edit-date) move into `useNisabRecordActions`. Page-level side effects are injected callbacks (`onCreated`, `onDeleted`, `onDateSaved`) so the hook is page-agnostic and independently testable — 9 unit tests cover payload shaping (354-day hawl window, zero zakat below nisab, threshold string), failure paths, confirm-gated actions, and the no-op date guard.

## Final numbers for #341
- Page: **263 lines** — **63% reduction** from 717 at issue filing
- Path: 717 → 410 (slice 1, #356) → 377 (#362) → 329 (#363) → 263
- The page is now state + layout only, composing three extracted panels + the actions hook
- Client suite: **535 passed / 1 documented skip** · tsc clean · build green

Closes #341.