### PR TITLE
refactor(#361): semantic tokens — nisab surfaces + shared Modal

### DIFF
--- a/client/src/components/nisab/CreateRecordModal.tsx
+++ b/client/src/components/nisab/CreateRecordModal.tsx
@@ -124,12 +124,12 @@ export const CreateRecordModal: React.FC<CreateRecordModalProps> = ({
     <Modal isOpen={open} onClose={onClose} title={`Create Nisab Record - Step ${step} of 3`} size="lg">
       {/* Step Indicator */}
       <div className="mb-4">
-        <div className="text-sm text-gray-500 mb-2">
+        <div className="text-sm text-muted-foreground mb-2">
           {step === 1 && "Confirm the assets to include in this Zakat year calculation."}
           {step === 2 && "Deduct valid liabilities to determine your net Zakatable wealth."}
           {step === 3 && "Review your configuration and set the Nisab Standard."}
         </div>
-        <div className="w-full bg-gray-200 rounded-full h-2">
+        <div className="w-full bg-muted rounded-full h-2">
           <div className="bg-blue-600 h-2 rounded-full transition-all duration-300" style={{ width: `${(step / 3) * 100}%` }}></div>
         </div>
       </div>
@@ -138,8 +138,8 @@ export const CreateRecordModal: React.FC<CreateRecordModalProps> = ({
         {step === 1 && (
           <div className="space-y-4">
             <div className="flex justify-between items-center">
-              <h3 className="text-sm font-medium text-gray-900">Inclusive Assets</h3>
-              <span className="text-xs text-gray-500">{selectedAssetIds.length} selected</span>
+              <h3 className="text-sm font-medium text-card-foreground">Inclusive Assets</h3>
+              <span className="text-xs text-muted-foreground">{selectedAssetIds.length} selected</span>
             </div>
             <AssetSelectionTable
               assets={allAssets}
@@ -157,8 +157,8 @@ export const CreateRecordModal: React.FC<CreateRecordModalProps> = ({
         {step === 2 && (
           <div className="space-y-4">
             <div className="flex justify-between items-center">
-              <h3 className="text-sm font-medium text-gray-900">Deductible Liabilities</h3>
-              <span className="text-xs text-gray-500">{selectedLiabilityIds.length} selected</span>
+              <h3 className="text-sm font-medium text-card-foreground">Deductible Liabilities</h3>
+              <span className="text-xs text-muted-foreground">{selectedLiabilityIds.length} selected</span>
             </div>
             <LiabilitySelectionTable
               liabilities={allLiabilities}
@@ -181,11 +181,11 @@ export const CreateRecordModal: React.FC<CreateRecordModalProps> = ({
         {step === 3 && (
           <div className="space-y-6">
             <div className="grid grid-cols-2 gap-4">
-              <div className="bg-gray-50 p-4 rounded text-center">
-                <span className="block text-xs text-gray-500 uppercase">Total Assets</span>
-                <span className="block text-xl font-bold text-gray-900">{new Intl.NumberFormat('en-US', { style: 'currency', currency: userCurrency }).format(preview.totalWealth)}</span>
+              <div className="bg-muted p-4 rounded text-center">
+                <span className="block text-xs text-muted-foreground uppercase">Total Assets</span>
+                <span className="block text-xl font-bold text-card-foreground">{new Intl.NumberFormat('en-US', { style: 'currency', currency: userCurrency }).format(preview.totalWealth)}</span>
               </div>
-              <div className="bg-gray-50 p-4 rounded text-center border border-green-100 bg-green-50">
+              <div className="bg-muted p-4 rounded text-center border border-green-100 bg-green-50">
                 <span className="block text-xs text-green-700 uppercase font-medium">Net Zakatable</span>
                 <span className="block text-xl font-bold text-green-700">{new Intl.NumberFormat('en-US', { style: 'currency', currency: userCurrency }).format(preview.netZakatableWealth)}</span>
               </div>
@@ -201,32 +201,32 @@ export const CreateRecordModal: React.FC<CreateRecordModalProps> = ({
             </div>
 
             <div className="space-y-2">
-              <label className="block text-sm font-medium text-gray-700">Select Nisab Standard</label>
+              <label className="block text-sm font-medium text-card-foreground">Select Nisab Standard</label>
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                <label className={`flex items-center justify-between p-4 rounded border cursor-pointer hover:bg-gray-50 transition-colors ${nisabBasis === 'GOLD' ? 'border-blue-500 bg-blue-50 ring-1 ring-blue-500' : 'border-gray-200'}`}>
+                <label className={`flex items-center justify-between p-4 rounded border cursor-pointer hover:bg-accent transition-colors ${nisabBasis === 'GOLD' ? 'border-blue-500 bg-blue-50 ring-1 ring-blue-500' : 'border-border'}`}>
                   <div className="flex items-center">
                     <input type="radio" name="nisab" checked={nisabBasis === 'GOLD'} onChange={() => setNisabBasis('GOLD')} className="mr-3 h-4 w-4 text-blue-600" />
                     <div>
-                      <span className="block font-medium text-gray-900">Gold Standard</span>
-                      <span className="text-xs text-gray-500">For Wealthy/Safer</span>
+                      <span className="block font-medium text-card-foreground">Gold Standard</span>
+                      <span className="text-xs text-muted-foreground">For Wealthy/Safer</span>
                     </div>
                   </div>
                   <span className="text-xs font-mono bg-yellow-100 text-yellow-800 px-2 py-1 rounded">87.48g</span>
                 </label>
-                <label className={`flex items-center justify-between p-4 rounded border cursor-pointer hover:bg-gray-50 transition-colors ${nisabBasis === 'SILVER' ? 'border-blue-500 bg-blue-50 ring-1 ring-blue-500' : 'border-gray-200'}`}>
+                <label className={`flex items-center justify-between p-4 rounded border cursor-pointer hover:bg-accent transition-colors ${nisabBasis === 'SILVER' ? 'border-blue-500 bg-blue-50 ring-1 ring-blue-500' : 'border-border'}`}>
                   <div className="flex items-center">
                     <input type="radio" name="nisab" checked={nisabBasis === 'SILVER'} onChange={() => setNisabBasis('SILVER')} className="mr-3 h-4 w-4 text-blue-600" />
                     <div>
-                      <span className="block font-medium text-gray-900">Silver Standard</span>
-                      <span className="text-xs text-gray-500">For Low Income</span>
+                      <span className="block font-medium text-card-foreground">Silver Standard</span>
+                      <span className="text-xs text-muted-foreground">For Low Income</span>
                     </div>
                   </div>
-                  <span className="text-xs font-mono bg-gray-100 text-gray-800 px-2 py-1 rounded">612.36g</span>
+                  <span className="text-xs font-mono bg-muted text-muted-foreground px-2 py-1 rounded">612.36g</span>
                 </label>
               </div>
             </div>
 
-            <div className="bg-gray-50 p-4 rounded text-center border border-blue-100 bg-blue-50">
+            <div className="bg-muted p-4 rounded text-center border border-blue-100 bg-blue-50">
               <span className="block text-xs text-blue-700 uppercase font-medium">Zakat Amount ({nisabBasis === 'GOLD' ? 'Gold' : 'Silver'})</span>
               <span className="block text-xl font-bold text-blue-700">
                 {new Intl.NumberFormat('en-US', { style: 'currency', currency: userCurrency }).format(zakatAmount)}
@@ -236,7 +236,7 @@ export const CreateRecordModal: React.FC<CreateRecordModalProps> = ({
         )}
       </div>
 
-      <div className="mt-6 flex justify-between w-full pt-4 border-t border-gray-100">
+      <div className="mt-6 flex justify-between w-full pt-4 border-t border-border">
         {step > 1 ? (
           <Button variant="outline" onClick={handleBack}>
             ← Back

--- a/client/src/components/nisab/NisabRecordCard.tsx
+++ b/client/src/components/nisab/NisabRecordCard.tsx
@@ -66,13 +66,13 @@ export const NisabRecordCard: React.FC<NisabRecordCardProps> = React.memo(({
   return (
     <div
       onClick={onSelect}
-      className={`border rounded-lg p-4 sm:p-5 cursor-pointer transition-all ${shouldHideOnMobile ? 'hidden lg:block' : ''} ${isSelected ? 'border-blue-500 bg-blue-50 shadow-md' : 'border-gray-200 bg-white hover:bg-gray-50 shadow-sm hover:shadow-md'}`}
+      className={`border rounded-lg p-4 sm:p-5 cursor-pointer transition-all ${shouldHideOnMobile ? 'hidden lg:block' : ''} ${isSelected ? 'border-blue-500 bg-blue-50 shadow-md' : 'border-border bg-card hover:bg-accent shadow-sm hover:shadow-md'}`}
     >
       <div className="space-y-3">
         {/* Header */}
         <div className="flex items-start justify-between gap-3">
           <div className="flex items-center gap-2 sm:gap-3 min-w-0">
-            <h3 className="text-base sm:text-lg font-semibold text-gray-900 truncate">
+            <h3 className="text-base sm:text-lg font-semibold text-card-foreground truncate">
               {Number(record.hijriYear || 0) > 0
                 ? `${record.hijriYear} H • ${startDateFormatted.split(',')[1]?.trim() || startDateFormatted}`
                 : startDateFormatted}
@@ -87,41 +87,41 @@ export const NisabRecordCard: React.FC<NisabRecordCardProps> = React.memo(({
         {/* Stats */}
         <div className="grid grid-cols-2 gap-3 sm:gap-4">
           <div>
-            <div className="text-xs text-gray-600 mb-1">Nisab Basis</div>
-            <div className="text-sm font-medium text-gray-900">
+            <div className="text-xs text-muted-foreground mb-1">Nisab Basis</div>
+            <div className="text-sm font-medium text-card-foreground">
               {record.nisabBasis === 'GOLD' ? '🟡 Gold' : '⚪ Silver'}
             </div>
           </div>
           {totalWealth > 0 && (
             <div>
-              <div className="text-xs text-gray-600 mb-1">Total Wealth</div>
-              <div className="text-sm font-medium text-gray-900">{formatCurrency(totalWealth, currency)}</div>
+              <div className="text-xs text-muted-foreground mb-1">Total Wealth</div>
+              <div className="text-sm font-medium text-card-foreground">{formatCurrency(totalWealth, currency)}</div>
             </div>
           )}
           {zakatableWealth > 0 && (
             <div>
-              <div className="text-xs text-gray-600 mb-1">Zakatable</div>
+              <div className="text-xs text-muted-foreground mb-1">Zakatable</div>
               <div className="text-sm font-medium text-green-700">{formatCurrency(zakatableWealth, currency)}</div>
             </div>
           )}
           {zakatAmount > 0 && (
             <div>
-              <div className="text-xs text-gray-600 mb-1">Zakat Obligation</div>
+              <div className="text-xs text-muted-foreground mb-1">Zakat Obligation</div>
               <div className="text-sm font-bold text-blue-700">{formatCurrency(zakatAmount, currency)}</div>
             </div>
           )}
         </div>
 
         {/* Dates */}
-        <div className="flex flex-col gap-1 text-xs text-gray-600">
+        <div className="flex flex-col gap-1 text-xs text-muted-foreground">
           <div>
-            Started: <span className="text-gray-900 font-medium">{startDateFormatted}</span>
-            <span className="text-gray-500 ml-1">({formatHijriDate(gregorianToHijri(startDate))})</span>
+            Started: <span className="text-card-foreground font-medium">{startDateFormatted}</span>
+            <span className="text-muted-foreground ml-1">({formatHijriDate(gregorianToHijri(startDate))})</span>
           </div>
           {record.hawlCompletionDate && (
             <div>
-              Ends: <span className="text-gray-900 font-medium">{new Date(record.hawlCompletionDate).toLocaleDateString()}</span>
-              <span className="text-gray-500 ml-1">({formatHijriDate(gregorianToHijri(new Date(record.hawlCompletionDate)))})</span>
+              Ends: <span className="text-card-foreground font-medium">{new Date(record.hawlCompletionDate).toLocaleDateString()}</span>
+              <span className="text-muted-foreground ml-1">({formatHijriDate(gregorianToHijri(new Date(record.hawlCompletionDate)))})</span>
             </div>
           )}
         </div>
@@ -129,11 +129,11 @@ export const NisabRecordCard: React.FC<NisabRecordCardProps> = React.memo(({
         {/* Actions */}
         <div className="flex gap-2 flex-wrap relative">
           {isSelected && record.status === 'DRAFT' && (
-            <button onClick={onEditDate} className="px-3 py-1 bg-gray-100 text-gray-700 rounded text-xs border border-gray-300 hover:bg-gray-200">Change Date</button>
+            <button onClick={onEditDate} className="px-3 py-1 bg-muted text-muted-foreground rounded text-xs border border-border hover:bg-accent">Change Date</button>
           )}
 
           {showEditPopover && (
-            <div className="absolute bg-white border p-4 shadow-xl z-20 rounded-lg w-72" onClick={e => e.stopPropagation()}>
+            <div className="absolute bg-card border-border border p-4 shadow-xl z-20 rounded-lg w-72" onClick={e => e.stopPropagation()}>
               <EditDatePopover value={newStartDate} onChange={onDateChange} onSave={onSaveDate} onCancel={onCancelDate} />
             </div>
           )}
@@ -144,7 +144,7 @@ export const NisabRecordCard: React.FC<NisabRecordCardProps> = React.memo(({
           {record.status === 'FINALIZED' && (
             <>
               <button onClick={onUnlock} className="px-2 py-1 bg-amber-600 text-white rounded text-xs">Unlock</button>
-              <button onClick={onGeneratePdf} className="px-2 py-1 bg-gray-100 text-gray-700 border border-gray-300 rounded text-xs hover:bg-gray-200 flex items-center gap-1">📄 PDF</button>
+              <button onClick={onGeneratePdf} className="px-2 py-1 bg-muted text-muted-foreground border border-border rounded text-xs hover:bg-accent flex items-center gap-1">📄 PDF</button>
             </>
           )}
           <button onClick={onDelete} className="px-2 py-1 text-red-600 hover:bg-red-50 rounded text-xs">Delete</button>

--- a/client/src/components/nisab/RecordRulingsPanel.tsx
+++ b/client/src/components/nisab/RecordRulingsPanel.tsx
@@ -88,12 +88,12 @@ export const RecordRulingsPanel: React.FC<RecordRulingsPanelProps> = ({
   }
 
   return (
-    <div className={`bg-white border border-gray-200 rounded-lg p-4 ${className}`} data-testid="record-rulings-panel">
+    <div className={`bg-card border-border rounded-lg p-4 border ${className}`} data-testid="record-rulings-panel">
       <div className="flex items-center gap-2 mb-3">
-        <Scale className="h-4 w-4 text-gray-500" aria-hidden="true" />
-        <h3 className="font-semibold text-gray-900 text-sm">Why each asset counts the way it does</h3>
+        <Scale className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+        <h3 className="font-semibold text-card-foreground text-sm">Why each asset counts the way it does</h3>
       </div>
-      <p className="text-xs text-gray-500 mb-3">
+      <p className="text-xs text-muted-foreground mb-3">
         Rulings under your selected methodology, with sources. Expand any asset for details.
       </p>
       <div className="space-y-2">
@@ -108,7 +108,7 @@ export const RecordRulingsPanel: React.FC<RecordRulingsPanelProps> = ({
           );
         })}
       </div>
-      <p className="text-xs text-gray-400 italic mt-3">
+      <p className="text-xs text-muted-foreground/70 italic mt-3">
         Educational guidance only — for specific situations, consult a qualified scholar.
       </p>
     </div>

--- a/client/src/components/ui/Modal.tsx
+++ b/client/src/components/ui/Modal.tsx
@@ -71,7 +71,7 @@ export const Modal: React.FC<ModalProps> = ({
               leaveTo="opacity-0 scale-95"
             >
               <Dialog.Panel className={clsx(
-                'w-full transform overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl transition-all',
+                'w-full transform overflow-hidden rounded-2xl bg-card border border-border p-6 text-left align-middle shadow-xl transition-all',
                 sizeClasses[size]
               )}>
                 {(title || showCloseButton) && (
@@ -79,7 +79,7 @@ export const Modal: React.FC<ModalProps> = ({
                     {title && (
                       <Dialog.Title
                         as="h3"
-                        className="text-lg font-medium leading-6 text-gray-900"
+                        className="text-lg font-medium leading-6 text-card-foreground"
                       >
                         {title}
                       </Dialog.Title>
@@ -87,7 +87,7 @@ export const Modal: React.FC<ModalProps> = ({
                     {showCloseButton && (
                       <button
                         type="button"
-                        className="rounded-md bg-white text-gray-400 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+                        className="rounded-md bg-transparent text-muted-foreground hover:text-card-foreground focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
                         onClick={onClose}
                       >
                         <span className="sr-only">Close</span>


### PR DESCRIPTION
## Issue #361 — token migration, batch 2 (nisab page + Modal shell)

Per the rollout order in the issue: completes the nisab records page after the #359 PaymentHistoryCard pilot.

- **NisabRecordCard** — 16 replacements (card, stat labels, date rows, action buttons, date popover)
- **RecordRulingsPanel** — 5 (header, body, footnote)
- **CreateRecordModal** — 22 (progress track, section headers, preview tiles, nisab-basis cards, footer)
- **components/ui/Modal.tsx** — shared shell: panel `bg-white` → `bg-card` + `border-border`, title + close button tokens. Every dialog in the app inherits this.

Tinted state variants (border-blue-500 selected chips, green/blue info tiles) intentionally left raw — semantic 'selected/warning/info' colors, already dark-adapted by the #365 retrofit.

**Verified**: dark modal + card + rulings screenshots, computed `bg-card` = navy in dark / white in light; suite 535 pass, tsc clean, build green.