### PR TITLE
refactor(#361): semantic tokens — Dashboard, AssetList, AssetCard

### DIFF
--- a/client/src/components/assets/AssetCard.tsx
+++ b/client/src/components/assets/AssetCard.tsx
@@ -39,7 +39,7 @@ export const AssetCard: React.FC<AssetCardProps> = ({ asset, onClick, onEdit, on
   const zakatableAmount = getAssetZakatableValue(asset, 'STANDARD');
   const effectiveModifier = asset.value > 0 ? zakatableAmount / asset.value : (isEligible ? 1.0 : 0);
 
-  const modifierBadge = isEligible ? getModifierBadge(effectiveModifier) : { icon: '🚫', text: 'Exempt', color: 'bg-gray-100 text-gray-600' };
+  const modifierBadge = isEligible ? getModifierBadge(effectiveModifier) : { icon: '🚫', text: 'Exempt', color: 'bg-muted text-muted-foreground' };
   const zakatOwed = zakatableAmount * 0.025; // Estimate at 2.5%
 
   const getCategoryIcon = (type: string): string => {
@@ -83,7 +83,7 @@ export const AssetCard: React.FC<AssetCardProps> = ({ asset, onClick, onEdit, on
 
   return (
     <div
-      className="bg-white border border-gray-200 rounded-lg shadow-sm hover:shadow-md transition-shadow p-4 cursor-pointer"
+      className="bg-card border-border rounded-lg shadow-sm hover:shadow-md transition-shadow p-4 cursor-pointer"
       onClick={onClick}
       role="article"
       aria-label={`Asset: ${asset.name}`}
@@ -95,10 +95,10 @@ export const AssetCard: React.FC<AssetCardProps> = ({ asset, onClick, onEdit, on
             {getCategoryIcon(asset.type)}
           </span>
           <div className="flex-1">
-            <h3 className="font-semibold text-gray-900 text-sm md:text-base">
+            <h3 className="font-semibold text-card-foreground text-sm md:text-base">
               {asset.name}
             </h3>
-            <p className="text-xs text-gray-500 capitalize">
+            <p className="text-xs text-muted-foreground capitalize">
               {asset.subCategory ? (
                 <span>
                   {asset.subCategory.replace(/_/g, ' ')} • {asset.type.replace(/_/g, ' ').toLowerCase()}
@@ -112,7 +112,7 @@ export const AssetCard: React.FC<AssetCardProps> = ({ asset, onClick, onEdit, on
 
         {/* Modifier Badge */}
         <div
-          className={`px-2 py-1 rounded text-xs font-medium ${!isEligible ? 'bg-gray-100 text-gray-600' : modifierBadge.color
+          className={`px-2 py-1 rounded text-xs font-medium ${!isEligible ? 'bg-muted text-muted-foreground' : modifierBadge.color
             } whitespace-nowrap ml-2`}
           title={getModifierLabel(effectiveModifier)}
         >
@@ -124,30 +124,30 @@ export const AssetCard: React.FC<AssetCardProps> = ({ asset, onClick, onEdit, on
       </div>
 
       {/* Value Section */}
-      <div className="space-y-2 mb-4 border-t border-gray-100 pt-3">
+      <div className="space-y-2 mb-4 border-t border-border pt-3">
         <div className="flex justify-between items-center text-sm">
-          <span className="text-gray-600">Asset Value:</span>
-          <span className="font-semibold text-gray-900">{formatCurrency(asset.value)}</span>
+          <span className="text-muted-foreground">Asset Value:</span>
+          <span className="font-semibold text-card-foreground">{formatCurrency(asset.value)}</span>
         </div>
 
         {/* Zakatable Amount (only show if modifier applies) */}
         {effectiveModifier !== 1.0 && (
           <div className="flex justify-between items-center text-sm">
-            <span className="text-gray-600">Zakatable:</span>
+            <span className="text-muted-foreground">Zakatable:</span>
             <span className="font-medium text-blue-600">{formatCurrency(zakatableAmount)}</span>
           </div>
         )}
 
         {/* Estimated Zakat */}
-        <div className="flex justify-between items-center text-sm border-t border-gray-100 pt-2 mt-2">
-          <span className="font-medium text-gray-900">Estimated Zakat:</span>
+        <div className="flex justify-between items-center text-sm border-t border-border pt-2 mt-2">
+          <span className="font-medium text-card-foreground">Estimated Zakat:</span>
           <span className="font-bold text-green-600">{formatCurrency(zakatOwed)}</span>
         </div>
       </div>
 
       {/* Modifier Info (if applicable) */}
       {effectiveModifier !== 1.0 && (
-        <div className="text-xs text-gray-600 bg-gray-50 rounded px-2 py-2 mb-3">
+        <div className="text-xs text-muted-foreground bg-muted rounded px-2 py-2 mb-3">
           <p className="font-medium mb-1">
             {effectiveModifier === 0.3 ? '📊 30% Rule Applied' : effectiveModifier === 0.0 ? '⏸️ Deferred' : `◐ ${(effectiveModifier * 100).toFixed(1)}% Applied`}
           </p>
@@ -159,14 +159,14 @@ export const AssetCard: React.FC<AssetCardProps> = ({ asset, onClick, onEdit, on
       )}
 
       {/* Actions */}
-      <div className="flex gap-2 pt-3 border-t border-gray-100">
+      <div className="flex gap-2 pt-3 border-t border-border">
         {onEdit && (
           <button
             onClick={(e) => {
               e.stopPropagation();
               onEdit();
             }}
-            className="flex-1 px-3 py-2 text-xs font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 rounded transition-colors"
+            className="flex-1 px-3 py-2 text-xs font-medium text-muted-foreground bg-muted hover:bg-accent rounded transition-colors"
             aria-label={`Edit ${asset.name}`}
           >
             Edit

--- a/client/src/components/assets/AssetList.tsx
+++ b/client/src/components/assets/AssetList.tsx
@@ -80,12 +80,12 @@ export const AssetList: React.FC = () => {
   return (
     <div className="space-y-6">
       <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
-        <h1 className="text-3xl font-bold text-slate-900">My Assets</h1>
+        <h1 className="text-3xl font-bold text-card-foreground">My Assets</h1>
         <div className="flex items-center space-x-3">
-          <div className="bg-white border border-slate-200 rounded-lg p-1 flex shadow-sm">
+          <div className="bg-card border-border rounded-lg p-1 flex shadow-sm">
             <button
               onClick={() => setViewMode('grid')}
-              className={`p-1.5 rounded transition-colors ${viewMode === 'grid' ? 'bg-slate-100 text-slate-900' : 'text-slate-500 hover:text-slate-700'}`}
+              className={`p-1.5 rounded transition-colors ${viewMode === 'grid' ? 'bg-muted text-card-foreground' : 'text-muted-foreground hover:text-card-foreground'}`}
               aria-label="Grid View"
               title="Grid View"
             >
@@ -93,7 +93,7 @@ export const AssetList: React.FC = () => {
             </button>
             <button
               onClick={() => setViewMode('list')}
-              className={`p-1.5 rounded transition-colors ${viewMode === 'list' ? 'bg-slate-100 text-slate-900' : 'text-slate-500 hover:text-slate-700'}`}
+              className={`p-1.5 rounded transition-colors ${viewMode === 'list' ? 'bg-muted text-card-foreground' : 'text-muted-foreground hover:text-card-foreground'}`}
               aria-label="List View"
               title="List View"
             >
@@ -109,27 +109,27 @@ export const AssetList: React.FC = () => {
       {/* Visualization Section - Only show if assets exist */}
       {assets.length > 0 && (
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 animate-fade-in">
-          <div className="lg:col-span-2 bg-white rounded-lg border border-slate-200 p-6 shadow-sm">
+          <div className="lg:col-span-2 bg-card rounded-lg border-border p-6 shadow-sm border">
             <div className="h-full">
               <AssetsBreakdownChart assets={assets} />
             </div>
           </div>
 
-          <div className="bg-slate-50 rounded-lg border border-slate-200 p-6 flex flex-col justify-center">
-            <h2 className="text-lg font-semibold text-slate-900 mb-4">Summary</h2>
+          <div className="bg-muted rounded-lg border-border p-6 border flex flex-col justify-center">
+            <h2 className="text-lg font-semibold text-card-foreground mb-4">Summary</h2>
             <div className="space-y-4">
-              <div className="flex justify-between items-center border-b border-slate-200 pb-2">
-                <span className="text-slate-600">Total Assets</span>
-                <span className="font-bold text-lg text-slate-900">
+              <div className="flex justify-between items-center border-b border-border pb-2">
+                <span className="text-muted-foreground">Total Assets</span>
+                <span className="font-bold text-lg text-card-foreground">
                   {formatCurrency(totalAssets)}
                 </span>
               </div>
               <div className="flex justify-between items-center">
-                <span className="font-medium text-slate-900">{assets.length} items</span>
+                <span className="font-medium text-card-foreground">{assets.length} items</span>
               </div>
-              <div className="flex justify-between items-center pt-2 border-t border-slate-100 mt-2">
-                <span className="text-slate-600 font-medium">Estimated Zakat</span>
-                <span className="font-bold text-slate-900 text-blue-600">
+              <div className="flex justify-between items-center pt-2 border-t border-border mt-2">
+                <span className="text-muted-foreground font-medium">Estimated Zakat</span>
+                <span className="font-bold text-blue-600">
                   {formatCurrency(estimatedZakat)}
                 </span>
               </div>
@@ -151,9 +151,9 @@ export const AssetList: React.FC = () => {
         /* Loading state — prevents the "No assets yet" flash before RxDB resolves */
         <Card className="p-12 text-center">
           <div className="flex justify-center py-4" role="status" aria-live="polite">
-            <div className="h-8 w-8 animate-spin rounded-full border-4 border-slate-200 border-t-slate-600"></div>
+            <div className="h-8 w-8 animate-spin rounded-full border-4 border-border border-t-muted-foreground"></div>
           </div>
-          <p className="text-sm text-slate-500 mt-2">Loading your assets…</p>
+          <p className="text-sm text-muted-foreground mt-2">Loading your assets…</p>
         </Card>
       ) : error ? (
         /* Error state — honest failure, with a retry path */
@@ -161,19 +161,19 @@ export const AssetList: React.FC = () => {
           <div className="w-16 h-16 bg-red-50 rounded-full flex items-center justify-center mx-auto mb-4">
             <span className="text-2xl">⚠️</span>
           </div>
-          <h3 className="text-lg font-medium text-slate-900 mb-2">Couldn't load your assets</h3>
-          <p className="text-slate-500 mb-6">{error.message || 'Something went wrong reading your local data.'}</p>
+          <h3 className="text-lg font-medium text-card-foreground mb-2">Couldn't load your assets</h3>
+          <p className="text-muted-foreground mb-6">{error.message || 'Something went wrong reading your local data.'}</p>
           <Button onClick={() => window.location.reload()} variant="outline">
             Retry
           </Button>
         </Card>
       ) : assets.length === 0 ? (
         <Card className="p-12 text-center">
-          <div className="w-16 h-16 bg-slate-100 rounded-full flex items-center justify-center mx-auto mb-4">
-            <Plus className="h-8 w-8 text-slate-400" />
+          <div className="w-16 h-16 bg-muted rounded-full flex items-center justify-center mx-auto mb-4">
+            <Plus className="h-8 w-8 text-muted-foreground/70" />
           </div>
-          <h3 className="text-lg font-medium text-slate-900 mb-2">No assets yet</h3>
-          <p className="text-slate-500 mb-6">Add your first asset to start tracking your wealth.</p>
+          <h3 className="text-lg font-medium text-card-foreground mb-2">No assets yet</h3>
+          <p className="text-muted-foreground mb-6">Add your first asset to start tracking your wealth.</p>
           <Button onClick={() => navigate('/assets/new')}>
             Add Your First Asset
           </Button>
@@ -203,21 +203,21 @@ export const AssetList: React.FC = () => {
                 <div
                   key={asset.id}
                   onClick={() => navigate(`/assets/${asset.id}`)}
-                  className="bg-white p-4 rounded-lg border border-slate-200 shadow-sm active:bg-slate-50 transition-colors"
+                  className="bg-card p-4 rounded-lg border-border shadow-sm active:bg-accent transition-colors border"
                 >
                   <div className="flex justify-between items-start mb-2">
                     <div>
-                      <h3 className="font-semibold text-slate-900">{asset.name}</h3>
-                      <span className="inline-block mt-1 px-2 py-0.5 rounded text-xs font-medium bg-slate-100 text-slate-600 uppercase tracking-wide">
+                      <h3 className="font-semibold text-card-foreground">{asset.name}</h3>
+                      <span className="inline-block mt-1 px-2 py-0.5 rounded text-xs font-medium bg-muted text-muted-foreground uppercase tracking-wide">
                         {asset.type.replace(/_/g, ' ')}
                       </span>
                     </div>
                     <div className="text-right">
-                      <div className="font-bold text-slate-900">{formatCurrency(asset.value, asset.currency)}</div>
-                      <div className="text-xs text-slate-500">Zakatable: {formatCurrency(zakatableAmount, asset.currency)}</div>
+                      <div className="font-bold text-card-foreground">{formatCurrency(asset.value, asset.currency)}</div>
+                      <div className="text-xs text-muted-foreground">Zakatable: {formatCurrency(zakatableAmount, asset.currency)}</div>
                     </div>
                   </div>
-                  <div className="flex justify-end gap-3 mt-3 pt-3 border-t border-slate-100">
+                  <div className="flex justify-end gap-3 mt-3 pt-3 border-t border-border">
                     <button
                       onClick={(e) => { e.stopPropagation(); handleEdit(asset.id); }}
                       className="text-sm font-medium text-indigo-600 hover:text-indigo-700 px-3 py-1.5 bg-indigo-50 rounded"
@@ -237,19 +237,19 @@ export const AssetList: React.FC = () => {
           </div>
 
           {/* Desktop List View: Table */}
-          <div className="hidden md:block bg-white shadow-sm rounded-lg overflow-hidden border border-slate-200">
+          <div className="hidden md:block bg-card shadow-sm rounded-lg overflow-hidden border-border">
             <div className="overflow-x-auto">
-              <table className="min-w-full divide-y divide-slate-200">
-                <thead className="bg-slate-50">
+              <table className="min-w-full divide-y divide-border">
+                <thead className="bg-muted">
                   <tr>
-                    <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">Asset Name</th>
-                    <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-slate-500 uppercase tracking-wider">Type</th>
-                    <th scope="col" className="px-6 py-3 text-right text-xs font-medium text-slate-500 uppercase tracking-wider">Value</th>
-                    <th scope="col" className="px-6 py-3 text-right text-xs font-medium text-slate-500 uppercase tracking-wider">Zakatable</th>
-                    <th scope="col" className="px-6 py-3 text-right text-xs font-medium text-slate-500 uppercase tracking-wider">Actions</th>
+                    <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">Asset Name</th>
+                    <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">Type</th>
+                    <th scope="col" className="px-6 py-3 text-right text-xs font-medium text-muted-foreground uppercase tracking-wider">Value</th>
+                    <th scope="col" className="px-6 py-3 text-right text-xs font-medium text-muted-foreground uppercase tracking-wider">Zakatable</th>
+                    <th scope="col" className="px-6 py-3 text-right text-xs font-medium text-muted-foreground uppercase tracking-wider">Actions</th>
                   </tr>
                 </thead>
-                <tbody className="bg-white divide-y divide-slate-200">
+                <tbody className="bg-card divide-y divide-border">
                   {assets.map((asset) => {
                     const isEligible = asset.zakatEligible !== false;
                     const modifier = isEligible ? ((asset as any)?.calculationModifier || 1.0) : 0;
@@ -259,22 +259,22 @@ export const AssetList: React.FC = () => {
                       <tr
                         key={asset.id}
                         onClick={() => navigate(`/assets/${asset.id}`)}
-                        className="hover:bg-slate-50 cursor-pointer transition-colors"
+                        className="hover:bg-accent cursor-pointer transition-colors"
                       >
                         <td className="px-6 py-4 whitespace-nowrap">
                           <div className="flex items-center">
-                            <div className="text-sm font-medium text-slate-900">{asset.name}</div>
+                            <div className="text-sm font-medium text-card-foreground">{asset.name}</div>
                           </div>
                         </td>
                         <td className="px-6 py-4 whitespace-nowrap">
-                          <span className="px-2.5 py-0.5 rounded-full text-xs font-medium bg-slate-100 text-slate-800 uppercase tracking-wide">
+                          <span className="px-2.5 py-0.5 rounded-full text-xs font-medium bg-muted text-card-foreground uppercase tracking-wide">
                             {asset.type.replace(/_/g, ' ')}
                           </span>
                         </td>
-                        <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-semibold text-slate-900">
+                        <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-semibold text-card-foreground">
                           {formatCurrency(asset.value, asset.currency)}
                         </td>
-                        <td className="px-6 py-4 whitespace-nowrap text-right text-sm text-slate-600">
+                        <td className="px-6 py-4 whitespace-nowrap text-right text-sm text-muted-foreground">
                           {formatCurrency(zakatableAmount, asset.currency)}
                         </td>
                         <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">

--- a/client/src/components/dashboard/Dashboard.tsx
+++ b/client/src/components/dashboard/Dashboard.tsx
@@ -71,8 +71,8 @@ export const Dashboard: React.FC = () => {
       {/* Dashboard Header */}
       <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
         <div>
-          <h1 className="text-3xl font-bold text-slate-900 tracking-tight">Dashboard</h1>
-          <p className="mt-1 text-slate-500">
+          <h1 className="text-3xl font-bold text-card-foreground tracking-tight">Dashboard</h1>
+          <p className="mt-1 text-muted-foreground">
             Welcome to your secure, local-first Zakat vault.
           </p>
         </div>
@@ -93,16 +93,16 @@ export const Dashboard: React.FC = () => {
         {/* Total Assets */}
         <Card className="hover:shadow-md transition-shadow duration-300 border-l-4 border-l-emerald-500">
           <CardHeader className="flex flex-row items-center justify-between pb-2">
-            <CardTitle className="text-sm font-medium text-slate-500">
+            <CardTitle className="text-sm font-medium text-muted-foreground">
               Total Assets Value
             </CardTitle>
             <Wallet className="h-4 w-4 text-emerald-600" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold text-slate-900">
+            <div className="text-2xl font-bold text-card-foreground">
               {formatCurrency(totalAssetValue)}
             </div>
-            <p className="text-xs text-slate-500 mt-1">
+            <p className="text-xs text-muted-foreground mt-1">
               {converted
                 ? `Across ${assets.length} tracked assets`
                 : 'Updating exchange rates…'}
@@ -113,34 +113,34 @@ export const Dashboard: React.FC = () => {
         {/* Zakatable Assets */}
         <Card className="hover:shadow-md transition-shadow duration-300 border-l-4 border-l-amber-400">
           <CardHeader className="flex flex-row items-center justify-between pb-2">
-            <CardTitle className="text-sm font-medium text-slate-500">
+            <CardTitle className="text-sm font-medium text-muted-foreground">
               Zakatable Assets
             </CardTitle>
             <TrendingUp className="h-4 w-4 text-amber-500" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold text-slate-900">
+            <div className="text-2xl font-bold text-card-foreground">
               {zakatableAssets}
             </div>
-            <p className="text-xs text-slate-500 mt-1">
+            <p className="text-xs text-muted-foreground mt-1">
               Assets eligible for Zakat
             </p>
           </CardContent>
         </Card>
 
         {/* Zakat Due (Placeholder/Estimated) */}
-        <Card className="hover:shadow-md transition-shadow duration-300 border-l-4 border-l-slate-300">
+        <Card className="hover:shadow-md transition-shadow duration-300 border-l-4 border-l-border">
           <CardHeader className="flex flex-row items-center justify-between pb-2">
-            <CardTitle className="text-sm font-medium text-slate-500">
+            <CardTitle className="text-sm font-medium text-muted-foreground">
               Last Calculation
             </CardTitle>
-            <History className="h-4 w-4 text-slate-400" />
+            <History className="h-4 w-4 text-muted-foreground/70" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold text-slate-900">
+            <div className="text-2xl font-bold text-card-foreground">
               --
             </div>
-            <p className="text-xs text-slate-500 mt-1">
+            <p className="text-xs text-muted-foreground mt-1">
               <Link to="/history" className="text-emerald-600 hover:underline">View History</Link>
             </p>
           </CardContent>
@@ -156,7 +156,7 @@ export const Dashboard: React.FC = () => {
           </CardHeader>
           <CardContent>
             {assets.length === 0 ? (
-              <div className="text-center py-8 text-slate-500">
+              <div className="text-center py-8 text-muted-foreground">
                 <Wallet className="h-10 w-10 mx-auto mb-3 opacity-20" />
                 <p>No assets tracked yet.</p>
                 <Button variant="link" onClick={() => navigate('/assets/new')}>Add your first asset</Button>
@@ -164,18 +164,18 @@ export const Dashboard: React.FC = () => {
             ) : (
               <div className="space-y-4">
                 {assets.slice(0, 3).map((asset) => (
-                  <div key={asset.id} className="flex items-center justify-between p-3 bg-slate-50 rounded-lg group hover:bg-emerald-50/50 transition-colors">
+                  <div key={asset.id} className="flex items-center justify-between p-3 bg-muted rounded-lg group hover:bg-emerald-50/50 transition-colors">
                     <div className="flex items-center gap-3">
-                      <div className="h-10 w-10 rounded-full bg-white border border-slate-200 flex items-center justify-center text-lg shadow-sm">
+                      <div className="h-10 w-10 rounded-full bg-card border-border flex items-center justify-center text-lg shadow-sm">
                         {asset.type === 'CASH' ? '💵' : asset.type === 'GOLD' ? '🪙' : '📦'}
                       </div>
                       <div>
-                        <p className="font-medium text-slate-900 group-hover:text-emerald-900">{asset.name}</p>
-                        <p className="text-xs text-slate-500 capitalize">{asset.type.toLowerCase().replace('_', ' ')}</p>
+                        <p className="font-medium text-card-foreground group-hover:text-emerald-900">{asset.name}</p>
+                        <p className="text-xs text-muted-foreground capitalize">{asset.type.toLowerCase().replace('_', ' ')}</p>
                       </div>
                     </div>
                     <div className="text-right">
-                      <p className="font-semibold text-slate-900">{formatCurrency(asset.value, asset.currency)}</p>
+                      <p className="font-semibold text-card-foreground">{formatCurrency(asset.value, asset.currency)}</p>
                       {isAssetZakatable(asset, 'STANDARD') && <Badge variant="secondary" className="text-[10px] h-5">Zakatable</Badge>}
                     </div>
                   </div>
@@ -184,7 +184,7 @@ export const Dashboard: React.FC = () => {
             )}
           </CardContent>
           {assets.length > 0 && (
-            <CardFooter className="bg-slate-50/50 border-t border-slate-100 p-3">
+            <CardFooter className="bg-muted/50 border-t border-border p-3">
               <Link to="/assets" className="w-full text-center text-sm text-emerald-600 hover:text-emerald-700 font-medium flex items-center justify-center gap-1">
                 View All Assets <ArrowRight className="h-3 w-3" />
               </Link>


### PR DESCRIPTION
## Issue #361 — token migration, batch 3 (most-visited surfaces)

- **Dashboard.tsx** — 19 replacements (page heading, stat card labels/values, recent-assets rows, card footers)
- **AssetList.tsx** — 38 (view toggle, summary panel, grid/list/table views, loading spinner, error + empty states)
- **AssetCard.tsx** — 14 (card, badges, rows, action buttons)

Intentionally raw: gradient endpoints (`to-slate-900` on the emerald CTA card), translucent overlays (`bg-white/10`), tinted state colors.

Suite 535 pass / 1 documented skip, tsc clean, build green. Dark verified in the live rig; light values unchanged (tokens = same values in light).