### PR TITLE
fix(#310): IDR dashboard currency regression + liabilities error state (v0.15.2 user report)

### DIFF
--- a/client/src/__tests__/components/wealthSummaryCurrency.test.tsx
+++ b/client/src/__tests__/components/wealthSummaryCurrency.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2024 ZakApp Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this program. If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Regression tests for issue #310 (v0.15.2 user report).
+ *
+ * Scenario: an IDR user's dashboard showed "$42,000,000.00 / IDR" (hardcoded
+ * USD symbol) and an IDR total compared against a USD nisab (+343301.6%).
+ *
+ * Root causes covered here:
+ * 1. WealthSummaryCard formatted amounts with a literal `$` prefix while the
+ *    currency label showed the real preference.
+ * 2. Dashboard resolved the currency only from the auth-context blob.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '../../test-utils';
+import React from 'react';
+
+const mockUseMaskedCurrency = vi.fn((s: string) => s);
+vi.mock('../../contexts/PrivacyContext', () => ({
+  useMaskedCurrency: () => mockUseMaskedCurrency,
+}));
+
+import { WealthSummaryCard } from '../../components/dashboard/WealthSummaryCard';
+
+describe('WealthSummaryCard — issue #310 IDR regression', () => {
+  beforeEach(() => {
+    mockUseMaskedCurrency.mockClear();
+  });
+
+  it('renders IDR amounts with the IDR symbol, not a hardcoded $', () => {
+    render(
+      <WealthSummaryCard totalWealth={42_000_000} nisabThreshold={230_000_000} currency="IDR" />
+    );
+
+    // Total: Intl 'currency' style with IDR → "Rp42,000,000" style output
+    const total = screen.getByText(/42,000,000/);
+    expect(total).toBeTruthy();
+    expect(total.textContent).not.toContain('$');
+    expect(total.textContent).toMatch(/IDR/);
+  });
+
+  it('renders the nisab threshold in the display currency (no $ for IDR)', () => {
+    render(
+      <WealthSummaryCard totalWealth={300_000_000} nisabThreshold={230_000_000} currency="IDR" />
+    );
+
+    const nisabLine = screen.getByText(/Nisab:/);
+    expect(nisabLine.textContent).not.toContain('$');
+    expect(nisabLine.textContent).toMatch(/IDR/);
+  });
+
+  it('formats USD amounts with $ as before (no regression for USD users)', () => {
+    render(
+      <WealthSummaryCard totalWealth={12_500} nisabThreshold={12_230.58} currency="USD" />
+    );
+
+    const total = screen.getByText(/12,500/);
+    expect(total.textContent).toContain('$');
+  });
+
+  it('shows the Above/Below Nisab difference in the display currency', () => {
+    render(
+      <WealthSummaryCard totalWealth={300_000_000} nisabThreshold={230_000_000} currency="IDR" />
+    );
+
+    // difference = 70,000,000 → rendered with Rp, no $
+    const diff = screen.getByText(/\+IDR/);
+    expect(diff.textContent).not.toContain('$');
+  });
+});

--- a/client/src/components/dashboard/WealthSummaryCard.tsx
+++ b/client/src/components/dashboard/WealthSummaryCard.tsx
@@ -52,6 +52,19 @@ export const WealthSummaryCard: React.FC<WealthSummaryCardProps> = ({
   const differencePercentage = ((totalWealth - nisabThreshold) / nisabThreshold) * 100;
   const maskedCurrency = useMaskedCurrency();
 
+  // Issue #310 (v0.15.2 regression): amounts were hardcoded to `$` while the
+  // currency label below showed the real preference (e.g. IDR) — an IDR user
+  // saw "$42,000,000.00 / IDR". Format with the actual currency code instead.
+  const fmt = (amount: number) =>
+    maskedCurrency(
+      new Intl.NumberFormat('en-US', {
+        style: 'currency',
+        currency,
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 2,
+      }).format(amount)
+    );
+
   return (
     <div className="bg-white rounded-lg shadow-md p-4 sm:p-6 border border-gray-200">
       {/* Header */}
@@ -100,7 +113,7 @@ export const WealthSummaryCard: React.FC<WealthSummaryCardProps> = ({
       <div className="mb-4">
         <p className="text-sm text-gray-600 mb-1">Total Wealth</p>
         <p className="text-2xl sm:text-3xl md:text-4xl font-bold text-gray-900">
-          {maskedCurrency(`$${totalWealth.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`)}
+          {fmt(totalWealth)}
         </p>
         <p className="text-xs text-gray-500 mt-1">{currency}</p>
       </div>
@@ -113,13 +126,13 @@ export const WealthSummaryCard: React.FC<WealthSummaryCardProps> = ({
               {isAboveNisab ? 'Above Nisab' : 'Below Nisab'}
             </p>
             <p className="text-xs text-gray-600 mt-1">
-              Nisab: {maskedCurrency(`$${nisabThreshold.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`)}
+              Nisab: {fmt(nisabThreshold)}
             </p>
           </div>
 
           <div className="text-right">
             <p className={`text-lg font-bold ${isAboveNisab ? 'text-green-700' : 'text-red-700'}`}>
-              {maskedCurrency(`${isAboveNisab ? '+' : '-'}$${difference.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`)}
+              {`${isAboveNisab ? '+' : '-'}${fmt(difference)}`}
             </p>
             <p className="text-xs text-gray-600">
               {isAboveNisab ? '+' : ''}{differencePercentage.toFixed(1)}%

--- a/client/src/hooks/__tests__/useNisabThreshold.test.tsx
+++ b/client/src/hooks/__tests__/useNisabThreshold.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) 2024 ZakApp Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this program. If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Regression test for issue #310 (v0.15.2 user report).
+ *
+ * The nisab threshold hook built its React Query key from the requested
+ * currency but never SENT the currency to the server, so every user got the
+ * USD nisab. An IDR user's dashboard then compared an IDR total against a
+ * USD threshold (+343301.6% nonsense). The fetch must include
+ * ?currency=<code> so the server resolves metal prices in that currency.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+
+const fetchMock = vi.fn();
+vi.stubGlobal('fetch', fetchMock);
+
+import { useNisabThreshold } from '../useNisabThreshold';
+
+function nisabResponse(currency: string) {
+  return {
+    success: true,
+    data: {
+      currency,
+      effectiveDate: new Date().toISOString(),
+      lastUpdated: new Date().toISOString(),
+      goldPrice: { pricePerGram: 100, currency, nisabGrams: 87.48, nisabValue: 8748 },
+      silverPrice: { pricePerGram: 1, currency, nisabGrams: 612.36, nisabValue: 612.36 },
+    },
+  };
+}
+
+describe('useNisabThreshold — issue #310 currency param regression', () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => nisabResponse('IDR'),
+    });
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+  });
+
+  it('sends the requested currency as a query param', async () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    renderHook(() => useNisabThreshold('IDR', 'GOLD'), { wrapper });
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalled();
+    });
+
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain('/api/zakat/nisab');
+    expect(url).toContain('currency=IDR');
+  });
+
+  it('defaults to currency=USD when no currency is passed', async () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    fetchMock.mockClear();
+    renderHook(() => useNisabThreshold(), { wrapper });
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalled();
+    });
+
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain('currency=USD');
+  });
+});

--- a/client/src/hooks/useLiabilityRepository.ts
+++ b/client/src/hooks/useLiabilityRepository.ts
@@ -65,6 +65,13 @@ export function useLiabilityRepository() {
                             }
                         }
 
+                        // Coerce amount/deductibleAmount to numbers — legacy
+                        // docs can carry string amounts (encrypted anyOf schema),
+                        // which would silently string-concat totals.
+                        data.amount = Number(data.amount) || 0;
+                        if (data.deductibleAmount !== undefined && data.deductibleAmount !== null) {
+                            data.deductibleAmount = Number(data.deductibleAmount) || 0;
+                        }
                         return data;
                     }));
                 })

--- a/client/src/hooks/useNisabThreshold.ts
+++ b/client/src/hooks/useNisabThreshold.ts
@@ -50,8 +50,13 @@ async function fetchNisabThreshold(
   currency: string = 'USD',
   nisabBasis: 'GOLD' | 'SILVER' = 'GOLD'
 ): Promise<NisabThresholdData> {
-  // Call the existing /api/zakat/nisab endpoint using full API_BASE_URL
-  const response = await fetch(`${API_BASE_URL}/zakat/nisab`, {
+  // Call the existing /api/zakat/nisab endpoint using full API_BASE_URL.
+  // Issue #310 (user regression report, v0.15.2): the currency param was in
+  // the query key but never sent — the server always resolved via auth prefs
+  // and non-synced clients got USD, breaking cross-currency comparison
+  // against locally-stored (IDR etc.) totals.
+  const params = new URLSearchParams({ currency });
+  const response = await fetch(`${API_BASE_URL}/zakat/nisab?${params.toString()}`, {
     headers: {
       'Authorization': `Bearer ${localStorage.getItem('accessToken')}`
     }

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -31,6 +31,7 @@ import { SkeletonCard } from '../components/common/SkeletonLoader';
 import { AssetsBreakdownChart } from '../components/dashboard/AssetsBreakdownChart';
 import { useNisabThreshold } from '../hooks/useNisabThreshold';
 import { useMaskedCurrency } from '../contexts/PrivacyContext';
+import { useDisplayCurrency } from '../hooks/useDisplayCurrency';
 import type { Asset } from '../types';
 import { useBestAction } from '../hooks/useBestAction';
 import { GlossaryTerm } from '../components/common/GlossaryTerm';
@@ -266,7 +267,12 @@ export const Dashboard: React.FC = () => {
 
   // Get Nisab threshold (use live value for consistency with other pages)
   const nisabBasis = (activeRecord?.nisabBasis || 'GOLD') as 'GOLD' | 'SILVER';
-  const userCurrency = (user as any)?.settings?.currency || (user as any)?.preferences?.currency || 'USD';
+
+  // Issue #310 (v0.15.2 regression): resolve currency from the local RxDB
+  // settings store FIRST (baseCurrency) — the auth-context blob may lag or
+  // still say USD for users who set their currency locally.
+  const display = useDisplayCurrency();
+  const userCurrency = display.currency;
   const { nisabAmount } = useNisabThreshold(userCurrency, nisabBasis);
   const nisabThreshold = nisabAmount || 5000; // Default fallback
 
@@ -365,13 +371,13 @@ export const Dashboard: React.FC = () => {
             <WealthSummaryCard
               totalWealth={totalWealth}
               nisabThreshold={nisabThreshold}
-              currency={(user as any)?.settings?.currency || (user as any)?.preferences?.currency || 'USD'}
+              currency={userCurrency}
             />
 
             <div className="bg-white rounded-lg shadow-md p-6 border border-gray-200">
               <AssetsBreakdownChart
                 assets={assets}
-                currency={(user as any)?.settings?.currency || (user as any)?.preferences?.currency || 'USD'}
+                currency={userCurrency}
               />
             </div>
           </div>

--- a/client/src/pages/LiabilitiesPage.tsx
+++ b/client/src/pages/LiabilitiesPage.tsx
@@ -29,7 +29,7 @@ import { sumLiabilitiesInCurrency, FxRates } from '../utils/currencyNormalizatio
 import { formatCurrency as formatInCurrency } from '../utils/formatters';
 
 export const LiabilitiesPage: React.FC = () => {
-    const { liabilities, isLoading } = useLiabilityRepository();
+    const { liabilities, isLoading, error } = useLiabilityRepository();
     const [isModalOpen, setIsModalOpen] = useState(false);
     const [editingLiability, setEditingLiability] = useState<Liability | undefined>(undefined);
     const maskedCurrency = useMaskedCurrency();
@@ -48,6 +48,21 @@ export const LiabilitiesPage: React.FC = () => {
         setIsModalOpen(false);
         setEditingLiability(undefined);
     };
+
+    // Issue #310 (user report: Liabilities "keeps showing error"): the repo's
+    // error channel was never rendered, so a failure looped into a blank /
+    // broken page. Show an honest, retryable error state instead.
+    if (error) {
+        return (
+            <div className="space-y-6">
+                <h1 className="text-3xl font-heading font-bold text-gray-900 leading-tight">Liabilities</h1>
+                <div className="rounded-lg border border-red-200 bg-red-50 p-6 text-center" role="alert">
+                    <p className="text-red-800 font-medium">We couldn't load your liabilities.</p>
+                    <p className="text-sm text-red-700 mt-1">{error.message || 'An unexpected database error occurred.'} Your data stays safely on this device — try reloading the page.</p>
+                </div>
+            </div>
+        );
+    }
 
     if (isLoading) {
         return (


### PR DESCRIPTION
Closes #310 (user regression reported on v0.15.2 by @haamadh)

## User-visible bugs fixed
- **Dashboard**: IDR user saw `2,000,000.00` with an `IDR` label (hardcoded `$` in WealthSummaryCard) and their IDR wealth compared against a **USD nisab** → nonsense "+343301.6%". Root cause: `useNisabThreshold` put the currency in its React Query key but never sent it to the server — every user got the USD threshold. The hook now sends `?currency=<code>` (the server has resolved metal prices per currency since the earlier #310 server patch — the client just never asked).
- **Dashboard**: currency now resolves from the local RxDB settings store first (`baseCurrency`) instead of only the auth-context blob, which can lag or still say USD for users who set their currency locally.
- **WealthSummaryCard**: all amounts (total, nisab, difference) format via Intl with the user's currency — no more hardcoded `$`.
- **LiabilitiesPage**: the repo's error channel was never rendered, so a failure meant a blank/broken page — now an honest, descriptive error state. Legacy string amounts are coerced to numbers in the repository layer.

## Screenshot from the report (context)
Dashboard showed `2,000,000.00 / IDR`, `Above Nisab +$41,987,769.42` vs `Nisab: $12,230.58` (cross-currency), `+343301.6%`.

## Tests
6 new regression tests: WealthSummaryCard IDR/USD formatting ×4, nisab `?currency` param ×2.
- vitest: 540 passed / 1 documented skip
- tsc --noEmit: clean
- production build: green