### PR TITLE
fix(#310): LiabilitiesPage hooks before conditional returns (user error loop)

### DIFF
--- a/client/src/pages/LiabilitiesPage.tsx
+++ b/client/src/pages/LiabilitiesPage.tsx
@@ -33,6 +33,12 @@ export const LiabilitiesPage: React.FC = () => {
     const [isModalOpen, setIsModalOpen] = useState(false);
     const [editingLiability, setEditingLiability] = useState<Liability | undefined>(undefined);
     const maskedCurrency = useMaskedCurrency();
+    // Issue #310 round 5: currency resolution + FX rates must run BEFORE any
+    // conditional return — hooks called conditionally throw
+    // "Rendered more hooks than during the previous render" (the crash behind
+    // the user's "Liabilities keeps showing error" report).
+    const { currency: userCurrency } = useDisplayCurrency();
+    const fxRatesQuery = useFxRates();
 
     const handleAdd = () => {
         setEditingLiability(undefined);
@@ -76,9 +82,6 @@ export const LiabilitiesPage: React.FC = () => {
     // currencies; sum through the shared normalizer (same rule as assets),
     // and show an honest placeholder when FX rates are unavailable instead
     // of a raw apples+oranges total. Previously this page hardcoded USD.
-    // Currency resolution now via useDisplayCurrency (#341).
-    const { currency: userCurrency } = useDisplayCurrency();
-    const fxRatesQuery = useFxRates();
     const fxRates = fxRatesQuery?.data?.data?.rates as FxRates | undefined;
     const liabilityTotal = sumLiabilitiesInCurrency(liabilities, userCurrency, fxRates);
 


### PR DESCRIPTION
Follow-up to #373 — root cause of the user's 'Liabilities keeps showing error' report.

## Root cause
PR #373 added an honest error state to LiabilitiesPage but placed `if (error) return ...` **before** the `useDisplayCurrency()` / `useFxRates()` hook calls. Rendering that error state changed the hook count → React threw 'Rendered more hooks than during the previous render' → error boundary crash loop. Found by reproducing in a dev (unminified) build.

## Fix
- Moved both hooks above all conditional returns (rules-of-hooks).
- Verified live in dev + production builds with an IDR user: page renders, Rp formatting correct, error state still reachable.
- Structural hook-order sweep (brace-depth-aware) across all client pages/components: no other file has this pattern.

## Note for reviewers
The crash only manifested when the repository error channel fired — which is also why it looped for the user. The sync/noise errors logged in console are unrelated and non-fatal.