### PR TITLE
fix(#377): 404 catch-all — no more blank pages on undefined routes

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -87,6 +87,7 @@ const DiagnosticsPage = lazy(() => import('./pages/DiagnosticsPage'));
 
 // Tracking & Analytics pages - lazy loaded for optimal performance
 const NisabYearRecordsPage = lazy(() => import('./pages/NisabYearRecordsPage').then(m => ({ default: m.NisabYearRecordsPage })));
+const NotFoundPage = lazy(() => import('./pages/NotFoundPage').then(m => ({ default: m.NotFoundPage })));
 const PaymentsPage = lazy(() => import('./pages/PaymentsPage').then(m => ({ default: m.PaymentsPage })));
 const PaymentImportExport = lazy(() => import('./components/payments/PaymentImportExport').then(m => ({ default: m.PaymentImportExport })));
 const LiabilitiesPage = lazy(() => import('./pages/LiabilitiesPage').then(m => ({ default: m.LiabilitiesPage })));
@@ -450,6 +451,16 @@ function App() {
 
 
 
+
+                    {/* 404 catch-all — must stay last */}
+                    <Route
+                      path="*"
+                      element={
+                        <Suspense fallback={<PageLoadingFallback />}>
+                          <NotFoundPage />
+                        </Suspense>
+                      }
+                    />
 
                     <Route path="/" element={<Navigate to="/dashboard" replace />} />
                   </Routes>

--- a/client/src/pages/NotFoundPage.tsx
+++ b/client/src/pages/NotFoundPage.tsx
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2024 ZakApp Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+/**
+ * Catch-all 404 page. Rendered for any URL that doesn't match a route, so
+ * users never hit a silent blank page (previously only the skip-link
+ * rendered — see issue #377).
+ */
+export function NotFoundPage() {
+  return (
+    <div
+      className="flex flex-col items-center justify-center min-h-[60vh] px-4 text-center"
+      data-testid="not-found-page"
+    >
+      <h1 className="text-6xl font-bold text-gray-800 dark:text-gray-200 mb-4">
+        404
+      </h1>
+      <h2 className="text-xl font-semibold text-gray-700 dark:text-gray-300 mb-2">
+        Page not found
+      </h2>
+      <p className="text-gray-500 dark:text-gray-400 mb-6 max-w-md">
+        The page you're looking for doesn't exist or may have moved. Your
+        saved data is safe — use the links below to get back on track.
+      </p>
+      <nav className="flex flex-wrap gap-3 justify-center" aria-label="Helpful links">
+        <Link
+          to="/dashboard"
+          className="px-4 py-2 rounded bg-blue-600 text-white text-sm font-medium hover:bg-blue-700"
+        >
+          Go to Dashboard
+        </Link>
+        <Link
+          to="/nisab-records"
+          className="px-4 py-2 rounded border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 text-sm font-medium hover:bg-gray-50 dark:hover:bg-gray-800"
+        >
+          Nisab Records
+        </Link>
+        <Link
+          to="/calculator"
+          className="px-4 py-2 rounded border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 text-sm font-medium hover:bg-gray-50 dark:hover:bg-gray-800"
+        >
+          Quick Calculator
+        </Link>
+      </nav>
+    </div>
+  );
+}
+
+export default NotFoundPage;


### PR DESCRIPTION
Closes #377

- New `NotFoundPage` (lazy-loaded, AGPL header) with links to Dashboard / Nisab Records / Quick Calculator
- Wire `<Route path="*">` as the last route in `App.tsx` so any undefined URL renders a friendly 404 instead of a silent blank page

Gates: tsc clean · 540/540 tests · production build