### PR TITLE
fix(#370): dark-mode date input chrome + ZK pill truncation

### DIFF
--- a/client/src/components/layout/Layout.tsx
+++ b/client/src/components/layout/Layout.tsx
@@ -333,7 +333,7 @@ export const Layout: React.FC<LayoutProps> = ({ children }) => {
                     </div>
 
                     {/* User Name - Hidden on Mobile, Visible on Desktop */}
-                    <span className="hidden md:inline text-gray-700 text-sm font-medium">
+                    <span className="hidden md:inline text-gray-700 text-sm font-medium max-w-[12rem] truncate align-middle">
                       {user?.firstName || user?.username || user?.email?.split('@')[0]}
                     </span>
 

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -86,6 +86,9 @@
    controls with no bg utility (class rules win on specificity). */
 .dark select:not([class*="bg-"]) { background-color: hsl(var(--card)); }
 .dark input:not([class*="bg-"]):not([type="checkbox"]):not([type="radio"]) { background-color: hsl(var(--card)); }
+.dark input[type="date"], .dark input[type="datetime-local"], .dark input[type="time"], .dark input[type="month"] {
+  color-scheme: dark;
+}
 .dark body {
   background-color: hsl(222 47% 7%);
   color: hsl(210 40% 96%);


### PR DESCRIPTION
Closes #370

Both cosmetic findings from the #360 dark-mode sweep:

**1. Native date-input chrome in dark mode** — `.dark input[type=date|datetime-local|time|month]` now sets `color-scheme: dark`, so the calendar-picker chrome matches the dark surface instead of rendering light-gray UA defaults.

**2. ZK header pill overflow** — the account-identifier span (`ZK1:<iv>:<ciphertext>`, ~60 chars) is capped at `max-w-[12rem] truncate`, ellipsizing instead of overflowing narrow viewports.

Verified live on the production build: pill width capped at exactly 192px with truncation; date inputs report `color-scheme: dark` with card-surface background in dark mode. tsc clean · 540 tests · build clean.