### PR TITLE
fix(#371): sync disabled state — typed 503 + graceful vault-only fallback

### DIFF
--- a/client/src/services/SyncService.ts
+++ b/client/src/services/SyncService.ts
@@ -91,12 +91,24 @@ export class SyncService {
         authMethod: 'none'
     });
 
+    /**
+     * True when the backend answered 503 SYNC_DISABLED (local/dev install
+     * without CouchDB). Sync stays off; vault-only mode continues (issue #371).
+     */
+    private syncDisabled = false;
+    private syncDisabledWarned = false;
+
     constructor() { }
 
     /**
      * Get valid CouchDB credentials, refreshing if needed.
      */
     private async getCredentials(): Promise<SyncCredentials> {
+        // Issue #371: sync permanently unavailable on this backend — fail fast
+        // so callers log once instead of hammering a dead endpoint.
+        if (this.syncDisabled) {
+            throw new Error('SYNC_DISABLED');
+        }
         // Return cached credentials if still valid (with buffer time)
         if (this.syncCredentials && new Date() < new Date(this.syncCredentials.expiresAt.getTime() - TOKEN_REFRESH_BUFFER_MS)) {
             return this.syncCredentials;
@@ -139,6 +151,17 @@ export class SyncService {
 
         if (!response.ok) {
             const body = await response.json().catch(() => ({ error: 'Unknown error' }));
+            // Typed disabled-state (issue #371): backend without CouchDB config
+            // returns 503 SYNC_DISABLED — treat as permanent 'vault-only mode',
+            // not a transient failure.
+            if (response.status === 503 && body?.code === 'SYNC_DISABLED') {
+                this.syncDisabled = true;
+                if (!this.syncDisabledWarned) {
+                    logger.warn('Sync is disabled on this server (not configured). Continuing in local vault-only mode.');
+                    this.syncDisabledWarned = true;
+                }
+                throw new Error('SYNC_DISABLED');
+            }
             // Support both shapes: { message: '...', ... } and { error: { message: '...' } }
             const errMsg = body?.error?.message || body?.message || body?.error || `Credential request failed: ${response.status}`;
             throw new Error(errMsg);

--- a/server/.env.example
+++ b/server/.env.example
@@ -137,3 +137,16 @@ DEFAULT_MAX_NISAB_RECORDS=3
 DEFAULT_MAX_PAYMENTS=25
 DEFAULT_MAX_LIABILITIES=2
 
+
+# =====================================================
+# SYNC (CouchDB) — OPTIONAL for local development
+# =====================================================
+# Without these values the server runs fine but cross-device sync is
+# DISABLED: POST /api/sync/token responds 503 { code: 'SYNC_DISABLED' } and
+# clients automatically continue in local vault-only mode (issue #371).
+# To enable sync, deploy a CouchDB instance and fill in:
+#
+# COUCHDB_JWT_SECRET=<random-32-byte-hex>
+# COUCHDB_URL=http://localhost:5984
+# COUCHDB_ADMIN_USER=admin
+# COUCHDB_ADMIN_PASSWORD=<password>

--- a/server/src/routes/sync.ts
+++ b/server/src/routes/sync.ts
@@ -49,11 +49,15 @@ router.post('/token', authMiddleware, async (req: AuthenticatedRequest, res: Res
     logger.info('Sync token requested');
     try {
         if (!syncService.isConfigured()) {
-            logger.error('Sync token request failed: server not configured');
+            logger.warn('Sync token request: sync disabled (not configured) — returning typed 503');
 
-            return res.status(500).json({
-                error: 'Sync not configured',
-                message: 'Server missing COUCHDB_JWT_SECRET environment variable'
+            // Typed disabled-state (issue #371): local/dev installs without
+            // CouchDB config get an honest 503 the client treats as
+            // "sync unavailable", not a hard 500 that breaks page flows.
+            return res.status(503).json({
+                error: 'Sync disabled',
+                code: 'SYNC_DISABLED',
+                message: 'Server sync is not configured (missing COUCHDB_JWT_SECRET). Local vault-only mode continues to work.'
             });
         }
         console.log('Secret configured.');


### PR DESCRIPTION
Closes #371

Local/dev installs without CouchDB no longer break page flows:

**Server** — `POST /api/sync/token` returns a typed **503 `SYNC_DISABLED`** instead of a raw 500 when CouchDB isn't configured. Honest disabled-state per the issue's option (b).

**Client** — `SyncService` recognizes the shape, warns once (no chip spam), sets a permanent `syncDisabled` gate so `getCredentials()` fails fast and sync stays off. Local vault-only mode is unaffected — all data stays local.

**Docs** — `.env.example` gains a commented CouchDB section (option a) explaining sync is optional and how to enable it.

Gates: server 474/474 + tsc · client 540/540 + tsc · client build.