### PR TITLE
feat(#313): push notification subscriptions + Zakat due reminders

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -39,6 +39,7 @@
         "resend": "^6.4.2",
         "tsconfig-paths": "^4.2.0",
         "uuid": "^14.0.0",
+        "web-push": "^3.6.7",
         "zod": "^3.25.76"
       },
       "devDependencies": {
@@ -56,6 +57,7 @@
         "@types/redis": "^4.0.11",
         "@types/supertest": "^6.0.2",
         "@types/uuid": "^10.0.0",
+        "@types/web-push": "^3.6.4",
         "@typescript-eslint/eslint-plugin": "^7.18.0",
         "@typescript-eslint/parser": "^7.18.0",
         "eslint": "^8.57.0",
@@ -2092,6 +2094,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/web-push": {
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/@types/web-push/-/web-push-3.6.4.tgz",
+      "integrity": "sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "7.18.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.18.0.tgz",
@@ -2481,7 +2493,6 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -2580,6 +2591,18 @@
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      }
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -2690,6 +2713,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/bn.js": {
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
+      "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==",
+      "license": "MIT"
     },
     "node_modules/boolbase": {
       "version": "1.0.0",
@@ -4429,6 +4458,15 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/http_ece": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http_ece/-/http_ece-1.2.0.tgz",
+      "integrity": "sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -4467,7 +4505,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -5012,6 +5049,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
     },
     "node_modules/minimatch": {
       "version": "9.0.9",
@@ -6987,6 +7030,25 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/web-push": {
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/web-push/-/web-push-3.6.7.tgz",
+      "integrity": "sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "asn1.js": "^5.3.0",
+        "http_ece": "1.2.0",
+        "https-proxy-agent": "^7.0.0",
+        "jws": "^4.0.0",
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "web-push": "src/cli.js"
+      },
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/webidl-conversions": {

--- a/server/package.json
+++ b/server/package.json
@@ -52,6 +52,7 @@
     "resend": "^6.4.2",
     "tsconfig-paths": "^4.2.0",
     "uuid": "^14.0.0",
+    "web-push": "^3.6.7",
     "zod": "^3.25.76"
   },
   "devDependencies": {
@@ -69,6 +70,7 @@
     "@types/redis": "^4.0.11",
     "@types/supertest": "^6.0.2",
     "@types/uuid": "^10.0.0",
+    "@types/web-push": "^3.6.4",
     "@typescript-eslint/eslint-plugin": "^7.18.0",
     "@typescript-eslint/parser": "^7.18.0",
     "eslint": "^8.57.0",

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -53,6 +53,7 @@ model User {
   analyticsMetrics AnalyticsMetric[] @relation("UserAnalyticsMetrics")
   annualSummaries  AnnualSummary[]   @relation("UserAnnualSummaries")
   reminderEvents   ReminderEvent[]   @relation("UserReminderEvents")
+  pushSubscriptions PushSubscription[] @relation("UserPushSubscriptions")
 
   // Nisab Year Record Audit Trail (NEW - Feature 008)
   auditTrailEntries AuditTrailEntry[] @relation("UserAuditTrails")
@@ -940,4 +941,23 @@ model AssetAmountSnapshot {
   @@unique([assetId, date])
   @@index([assetId])
   @@index([date])
+}
+
+// ── Push Notifications (#313) ────────────────────────────────────────────────
+// Web Push subscriptions for Zakat due reminders. One user may register
+// several devices; `endpoint` is the browser-generated unique URL.
+model PushSubscription {
+  id        String   @id @default(cuid())
+  userId    String
+  endpoint  String   @unique // browser-generated subscription URL
+  p256dh    String   // client public key (Base64URL)
+  auth      String   // auth secret (Base64URL)
+  userAgent String?  // device hint for UX/debugging
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  user User @relation("UserPushSubscriptions", fields: [userId], references: [id], onDelete: Cascade)
+
+  @@map("push_subscriptions")
+  @@index([userId])
 }

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -27,6 +27,7 @@ import 'dotenv/config';
 // Import route modules
 import authRoutes from './routes/auth';
 import syncRoutes from './routes/sync';
+import pushRoutes from './routes/push';
 import assetRoutes from './routes/assets';
 import calculationsRoutes from './routes/calculations';
 import zakatRoutes from './routes/zakat';
@@ -178,6 +179,7 @@ app.use('/api/users', userRoutes); // Alias for consistency (hotfix for 404s)
 app.use('/api/calendar', calendarRoutes);
 app.use('/api/methodologies', methodologyRoutes);
 app.use('/api/feedback', feedbackRoutes);
+app.use('/api/push', pushRoutes);
 // app.use('/api/admin/encryption', adminEncryptionRoutes); // Replaced by generic admin routes
 app.use('/api/admin', adminRoutes);
 

--- a/server/src/routes/push.ts
+++ b/server/src/routes/push.ts
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2024 ZakApp Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Push notification subscription routes (#313)
+ *
+ * POST /api/push/subscribe    — store a Web Push subscription for the caller
+ * POST /api/push/unsubscribe  — remove a subscription by endpoint
+ * GET  /api/push/vapid-key    — public VAPID key for client subscription setup
+ */
+
+import { Router, Response } from 'express';
+import { z } from 'zod';
+import { authMiddleware } from '../middleware/auth';
+import { AuthenticatedRequest } from '../types';
+import { validateSchema } from '../middleware/ValidationMiddleware';
+import { Logger } from '../utils/logger';
+import {
+  subscribePush,
+  unsubscribePush,
+  getVapidPublicKey
+} from '../services/PushNotificationService';
+
+const logger = new Logger('PushRoutes');
+
+const router = Router();
+
+const subscribeSchema = z.object({
+  endpoint: z.string().url().max(2048),
+  keys: z.object({
+    p256dh: z.string().min(1).max(512),
+    auth: z.string().min(1).max(512)
+  }),
+  userAgent: z.string().max(512).optional()
+});
+
+const unsubscribeSchema = z.object({
+  endpoint: z.string().max(2048)
+});
+
+// Public VAPID key so browsers can subscribe before auth-dependent flows
+router.get('/vapid-key', (_req, res: Response) => {
+  res.json({ publicKey: getVapidPublicKey() });
+});
+
+router.post('/subscribe', authMiddleware, validateSchema(subscribeSchema), async (req: AuthenticatedRequest, res: Response) => {
+  try {
+    const user = req.user;
+    if (!user?.id) {
+      return res.status(401).json({ error: 'User not authenticated' });
+    }
+    const userAgent = Array.isArray(req.headers['user-agent'])
+      ? req.headers['user-agent'][0]
+      : req.headers['user-agent'];
+    await subscribePush(user.id, req.body, userAgent);
+    return res.status(201).json({ ok: true });
+  } catch (err) {
+    logger.error('Push subscribe failed:', err);
+    return res.status(500).json({ error: 'Failed to store subscription' });
+  }
+});
+
+router.post('/unsubscribe', authMiddleware, validateSchema(unsubscribeSchema), async (req: AuthenticatedRequest, res: Response) => {
+  try {
+    const user = req.user;
+    if (!user?.id) {
+      return res.status(401).json({ error: 'User not authenticated' });
+    }
+    await unsubscribePush(user.id, req.body.endpoint);
+    return res.json({ ok: true });
+  } catch (err) {
+    logger.error('Push unsubscribe failed:', err);
+    return res.status(500).json({ error: 'Failed to remove subscription' });
+  }
+});
+
+export default router;

--- a/server/src/services/PushNotificationService.ts
+++ b/server/src/services/PushNotificationService.ts
@@ -22,20 +22,37 @@
  * Uses Web Push protocol with VAPID authentication.
  */
 
-// Dynamically require optional dependency 'web-push' to avoid compile-time errors when it's not installed
-let webpush: any = null;
+// web-push is now a direct dependency (#313). Imported lazily via require to
+// keep the module resilient if the dependency is stripped in slim installs.
+import type * as WebPushTypes from 'web-push';
+let webpush: typeof WebPushTypes | null = null;
 try {
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   webpush = require('web-push');
 } catch (err) {
-  // web-push is optional in some environments (tests, CI). We'll handle absence gracefully.
+  // web-push absence is handled gracefully (push disabled).
   webpush = null;
+}
+
+/**
+ * Test seam (#313): override the web-push implementation (e.g. vi.mock in
+ * tests, where raw CJS require bypasses the ESM mock registry).
+ * @internal
+ */
+export function __setWebPushForTesting(impl: typeof WebPushTypes | null): void {
+  webpush = impl;
+  configureVapid();
 }
 
 import { Logger } from '../utils/logger';
 
 const logger = new Logger('PushNotificationService');
+import { prisma } from '../utils/prisma';
 
+
+// Reminder policy (#313): fire on these days-before-due within a 30-day window
+const REMINDER_DAYS = [30, 7, 1];
+const REMINDER_WINDOW_DAYS = 30;
 
 // VAPID keys for push notifications
 // In production, these should be environment variables
@@ -43,12 +60,12 @@ const VAPID_PUBLIC_KEY = process.env.VAPID_PUBLIC_KEY || '';
 const VAPID_PRIVATE_KEY = process.env.VAPID_PRIVATE_KEY || '';
 const VAPID_SUBJECT = process.env.VAPID_SUBJECT || 'mailto:admin@zakapp.com';
 
-// Configure web-push
-if (VAPID_PUBLIC_KEY && VAPID_PRIVATE_KEY) {
-  webpush.setVapidDetails(VAPID_SUBJECT, VAPID_PUBLIC_KEY, VAPID_PRIVATE_KEY);
-} else {
-  logger.warn('⚠️ VAPID keys not configured - push notifications will not work');
+function configureVapid(): void {
+  if (webpush && VAPID_PUBLIC_KEY && VAPID_PRIVATE_KEY) {
+    webpush.setVapidDetails(VAPID_SUBJECT, VAPID_PUBLIC_KEY, VAPID_PRIVATE_KEY);
+  }
 }
+configureVapid();
 
 export interface PushSubscription {
   endpoint: string;
@@ -79,6 +96,10 @@ export async function sendPushNotification(
   payload: NotificationPayload
 ): Promise<boolean> {
   try {
+    if (!webpush) {
+      logger.warn('⚠️ web-push unavailable — notification skipped');
+      return false;
+    }
     await webpush.sendNotification(subscription, JSON.stringify(payload));
     logger.info('✅ Push notification sent successfully');
     return true;
@@ -102,27 +123,62 @@ export async function sendPushToUser(
   payload: NotificationPayload
 ): Promise<void> {
   try {
-    // In a real implementation, fetch user's push subscriptions from database
-    // For now, this is a placeholder
+    const subscriptions = await prisma.pushSubscription.findMany({
+      where: { userId }
+    });
 
-    logger.info(`📤 Sending push notification to user: ${userId}`);
-    logger.info(`Notification: ${payload.title} - ${payload.body}`);
+    logger.info(`📤 Sending push notification to user ${userId} (${subscriptions.length} subscription(s))`);
 
-    // TODO(#313): Implement database schema for storing push subscriptions
-    // const subscriptions = await prisma.pushSubscription.findMany({
-    //   where: { userId }
-    // });
-
-    // for (const sub of subscriptions) {
-    //   const success = await sendPushNotification(sub.subscription, payload);
-    //   if (!success) {
-    //     // Remove expired subscription
-    //     await prisma.pushSubscription.delete({ where: { id: sub.id } });
-    //   }
-    // }
+    for (const sub of subscriptions) {
+      const success = await sendPushNotification(
+        { endpoint: sub.endpoint, keys: { p256dh: sub.p256dh, auth: sub.auth } },
+        payload
+      );
+      if (!success) {
+        // Subscription expired (410) or send failed unrecoverably — prune it
+        await prisma.pushSubscription.delete({ where: { id: sub.id } }).catch(() => undefined);
+      }
+    }
   } catch (error) {
     logger.error('❌ Failed to send push notification to user:', error);
   }
+}
+
+/**
+ * Persist a new push subscription for a user (idempotent on endpoint).
+ */
+export async function subscribePush(
+  userId: string,
+  subscription: PushSubscription,
+  userAgent?: string
+): Promise<void> {
+  await prisma.pushSubscription.upsert({
+    where: { endpoint: subscription.endpoint },
+    update: {
+      userId,
+      p256dh: subscription.keys.p256dh,
+      auth: subscription.keys.auth,
+      userAgent: userAgent ?? null
+    },
+    create: {
+      userId,
+      endpoint: subscription.endpoint,
+      p256dh: subscription.keys.p256dh,
+      auth: subscription.keys.auth,
+      userAgent: userAgent ?? null
+    }
+  });
+  logger.info(`✅ Push subscription stored for user ${userId}`);
+}
+
+/**
+ * Remove a push subscription (by endpoint, for the owning user).
+ */
+export async function unsubscribePush(userId: string, endpoint: string): Promise<void> {
+  await prisma.pushSubscription.deleteMany({
+    where: { userId, endpoint }
+  });
+  logger.info(`✅ Push subscription removed for user ${userId}`);
 }
 
 /**
@@ -194,26 +250,52 @@ export async function sendAssetUpdateReminder(
 export async function scheduleZakatReminders(): Promise<void> {
   try {
     logger.info('⏰ Scheduling Zakat reminders...');
-    // TODO(#313): Implement database schema for storing push subscriptions
-    // TODO(#313): Implement logic to find users whose Zakat is due soon
-    // const usersWithUpcomingZakat = await prisma.user.findMany({
-    //   where: {
-    //     zakatDueDate: {
-    //       gte: new Date(),
-    //       lte: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000), // Next 30 days
-    //     },
-    //   },
-    // });
 
-    // for (const user of usersWithUpcomingZakat) {
-    //   const daysUntilDue = Math.ceil(
-    //     (user.zakatDueDate.getTime() - Date.now()) / (24 * 60 * 60 * 1000)
-    //   );
-    //   
-    //   if (daysUntilDue === 30 || daysUntilDue === 7 || daysUntilDue === 1) {
-    //     await sendZakatReminder(user.id, daysUntilDue);
-    //   }
-    // }
+    // Hawl windows ending within the next 30 days that are not yet finalized
+    const now = new Date();
+    const windowEnd = new Date(now.getTime() + REMINDER_WINDOW_DAYS * 24 * 60 * 60 * 1000);
+
+    const snapshots = await prisma.yearlySnapshot.findMany({
+      where: {
+        hawlCompletionDate: { gte: now, lte: windowEnd },
+        status: { not: 'FINALIZED' }
+      },
+      select: { userId: true, hawlCompletionDate: true }
+    });
+
+    for (const snap of snapshots) {
+      if (!snap.hawlCompletionDate) continue;
+      const daysUntilDue = Math.ceil(
+        (snap.hawlCompletionDate.getTime() - now.getTime()) / (24 * 60 * 60 * 1000)
+      );
+
+      // Only fire on the configured reminder days (30 / 7 / 1)
+      if (!REMINDER_DAYS.includes(daysUntilDue)) continue;
+
+      // Dedupe: one ReminderEvent per user/day-marker; skip if already sent
+      const dedupeKey = `push_zakat_due_${daysUntilDue}`;
+      const alreadySent = await prisma.reminderEvent.findFirst({
+        where: {
+          userId: snap.userId,
+          eventType: dedupeKey,
+          triggerDate: snap.hawlCompletionDate
+        }
+      });
+      if (alreadySent) continue;
+
+      await sendZakatReminder(snap.userId, daysUntilDue);
+      await prisma.reminderEvent.create({
+        data: {
+          userId: snap.userId,
+          eventType: dedupeKey,
+          triggerDate: snap.hawlCompletionDate,
+          title: 'Zakat Reminder',
+          message: `Your Zakat calculation is due in ${daysUntilDue} days.`,
+          priority: daysUntilDue <= 7 ? 'high' : 'medium',
+          status: 'pending'
+        }
+      }).catch(err => logger.warn('ReminderEvent dedupe row not stored:', err));
+    }
 
     logger.info('✅ Zakat reminders scheduled successfully');
   } catch (error) {

--- a/server/tests/unit/services/pushNotificationService.test.ts
+++ b/server/tests/unit/services/pushNotificationService.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Copyright (c) 2024 ZakApp Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the prisma singleton BEFORE importing the service under test
+vi.mock('../../../src/utils/prisma', () => ({
+  prisma: {
+    pushSubscription: {
+      findMany: vi.fn(),
+      upsert: vi.fn(),
+      delete: vi.fn(),
+      deleteMany: vi.fn()
+    },
+    yearlySnapshot: {
+      findMany: vi.fn()
+    },
+    reminderEvent: {
+      findFirst: vi.fn(),
+      create: vi.fn()
+    }
+  }
+}));
+
+// Inject a controllable web-push implementation through the service's test
+// seam (raw CJS require inside the service bypasses vi.mock's registry).
+const mockSendNotification = vi.fn();
+const mockWebPush = { sendNotification: mockSendNotification } as any;
+
+import { prisma } from '../../../src/utils/prisma';
+import {
+  subscribePush,
+  unsubscribePush,
+  sendPushToUser,
+  scheduleZakatReminders,
+  __setWebPushForTesting
+} from '../../../src/services/PushNotificationService';
+
+describe('PushNotificationService (#313)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    __setWebPushForTesting(mockWebPush);
+  });
+
+  describe('subscribePush', () => {
+    it('upserts a subscription keyed by endpoint', async () => {
+      const sub = {
+        endpoint: 'https://push.example.com/abc123',
+        keys: { p256dh: 'key-p256dh', auth: 'key-auth' }
+      };
+
+      await subscribePush('user1', sub, 'UA/1.0');
+
+      expect(prisma.pushSubscription.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { endpoint: sub.endpoint },
+          create: expect.objectContaining({
+            userId: 'user1',
+            endpoint: sub.endpoint,
+            p256dh: 'key-p256dh',
+            auth: 'key-auth',
+            userAgent: 'UA/1.0'
+          }),
+          update: expect.objectContaining({ userId: 'user1' })
+        })
+      );
+    });
+
+    it('stores null userAgent when not provided', async () => {
+      await subscribePush('user1', {
+        endpoint: 'https://push.example.com/x',
+        keys: { p256dh: 'k', auth: 'a' }
+      });
+
+      expect(prisma.pushSubscription.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          create: expect.objectContaining({ userAgent: null })
+        })
+      );
+    });
+  });
+
+  describe('unsubscribePush', () => {
+    it('deletes only the caller endpoint', async () => {
+      await unsubscribePush('user1', 'https://push.example.com/abc123');
+
+      expect(prisma.pushSubscription.deleteMany).toHaveBeenCalledWith({
+        where: { userId: 'user1', endpoint: 'https://push.example.com/abc123' }
+      });
+    });
+  });
+
+  describe('sendPushToUser', () => {
+    it('sends to all stored subscriptions and prunes expired ones', async () => {
+      (prisma.pushSubscription.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([
+        { id: 's1', endpoint: 'https://push.example.com/live', p256dh: 'k1', auth: 'a1' },
+        { id: 's2', endpoint: 'https://push.example.com/dead', p256dh: 'k2', auth: 'a2' }
+      ]);
+      mockSendNotification.mockImplementation((sub) => {
+        if (sub.endpoint.includes('live')) return Promise.resolve();
+        const err: any = new Error('gone');
+        err.statusCode = 410;
+        return Promise.reject(err);
+      });
+
+      await sendPushToUser('user1', { title: 'T', body: 'B' });
+
+      expect(mockSendNotification).toHaveBeenCalledTimes(2);
+      // Expired subscription pruned; live one kept
+      expect(prisma.pushSubscription.delete).toHaveBeenCalledWith({ where: { id: 's2' } });
+      expect(prisma.pushSubscription.delete).not.toHaveBeenCalledWith({ where: { id: 's1' } });
+    });
+
+    it('succeeds silently when the user has no subscriptions', async () => {
+      (prisma.pushSubscription.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+      await expect(sendPushToUser('user1', { title: 'T', body: 'B' })).resolves.toBeUndefined();
+      expect(mockSendNotification).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('scheduleZakatReminders', () => {
+    const daysFromNow = (d: number) => new Date(Date.now() + d * 24 * 60 * 60 * 1000);
+
+    it('sends reminders on day 30/7/1 and stores dedupe rows', async () => {
+      (prisma.yearlySnapshot.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([
+        { userId: 'u1', hawlCompletionDate: daysFromNow(7) },
+        { userId: 'u2', hawlCompletionDate: daysFromNow(15) } // not a marker day
+      ]);
+      (prisma.reminderEvent.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+      (prisma.pushSubscription.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([
+        { id: 's1', endpoint: 'https://push.example.com/e', p256dh: 'k', auth: 'a' }
+      ]);
+      mockSendNotification.mockResolvedValue(undefined);
+
+      await scheduleZakatReminders();
+
+      // Only u1 (day 7 marker) sent
+      expect(mockSendNotification).toHaveBeenCalledTimes(1);
+      const payload = JSON.parse(mockSendNotification.mock.calls[0][1]);
+      expect(payload.title).toBe('Zakat Reminder');
+      expect(payload.data.daysUntilDue).toBe(7);
+      expect(prisma.reminderEvent.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ userId: 'u1', eventType: 'push_zakat_due_7' })
+        })
+      );
+    });
+
+    it('skips users who already received the reminder for that day marker', async () => {
+      (prisma.yearlySnapshot.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([
+        { userId: 'u1', hawlCompletionDate: daysFromNow(1) }
+      ]);
+      (prisma.reminderEvent.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: 'already'
+      });
+
+      await scheduleZakatReminders();
+
+      expect(mockSendNotification).not.toHaveBeenCalled();
+      expect(prisma.reminderEvent.create).not.toHaveBeenCalled();
+    });
+
+    it('ignores snapshots outside the 30-day window or finalized', async () => {
+      (prisma.yearlySnapshot.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+      await scheduleZakatReminders();
+      expect(mockSendNotification).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
Closes #313

## Server
- **Prisma** (additive-only): `PushSubscription` model — `endpoint` (unique browser URL), `p256dh`, `auth`, optional `userAgent`, cascade FK to User.
- **Service**: `subscribePush` (idempotent upsert on endpoint) · `unsubscribePush` · `sendPushToUser` (send to all devices, prune 410-expired subscriptions) · `scheduleZakatReminders` (scans non-finalized `YearlySnapshot.hawlCompletionDate` within 30 days; fires on day 30/7/1 markers; deduped via `ReminderEvent` rows).
- **Routes**: `GET /api/push/vapid-key` (public) · `POST /api/push/subscribe` · `POST /api/push/unsubscribe` — auth + zod-validated.
- `web-push` is now a real dependency; the service keeps its graceful no-push fallback and gains an injectable test seam (raw CJS require bypasses the ESM mock registry — documented inline).

## Tests
8 new unit tests: subscription CRUD, expired-sub pruning, day-marker firing, dedupe, no-subscriber no-op. Server suite **482/482**, tsc clean.

## Client subscription UI
Follow-up work (service worker registration + settings toggle) will ride a separate PR so this lands the server foundation cleanly first.