### PR TITLE
fix(#313): add missing PushSubscription migration

### DIFF
--- a/server/prisma/migrations/20260912160000_add_push_subscriptions/migration.sql
+++ b/server/prisma/migrations/20260912160000_add_push_subscriptions/migration.sql
@@ -1,0 +1,21 @@
+-- Additive-only: creates PushSubscription table for push notifications (#313).
+-- No drops, no renames, no data changes.
+
+-- CreateTable
+CREATE TABLE "push_subscriptions" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "userId" TEXT NOT NULL,
+    "endpoint" TEXT NOT NULL,
+    "p256dh" TEXT NOT NULL,
+    "auth" TEXT NOT NULL,
+    "userAgent" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "push_subscriptions_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "push_subscriptions_endpoint_key" ON "push_subscriptions"("endpoint");
+
+-- CreateIndex
+CREATE INDEX "push_subscriptions_userId_idx" ON "push_subscriptions"("userId");


### PR DESCRIPTION
Caught during the v0.16.0 production deploy verification.

## Problem
PR #382 shipped the PushSubscription model in `schema.prisma` + service/routes but **no Prisma migration** — production `prisma migrate deploy` never created `push_subscriptions` (unit tests passed because the test globalSetup falls back to `db push`).

## Fix
Additive-only migration `20260912160000_add_push_subscriptions`: CREATE TABLE + unique endpoint index + userId index + cascade FK to users. No drops, no renames, no data changes.

## Verified
- `prisma migrate deploy` on a scratch DB: all 11 migrations apply clean
- `p.pushSubscription.count()` works post-migration
- Server suite 482/482