### PR TITLE
Release v0.16.1 — patch (PushSubscription migration)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.16.1] - 2026-09-12
+
+### Patch — PushSubscription migration fix (#313)
+
+Production-deploy verification caught that PR #382 added the `PushSubscription` Prisma model without a migration — `prisma migrate deploy` never created the `push_subscriptions` table in production (unit tests passed because the test setup falls back to `db push`).
+
+- **Fixed**: additive-only migration `20260912160000_add_push_subscriptions` (CREATE TABLE + unique endpoint index + userId index + cascade FK to users). No drops, renames, or data changes. Verified on a scratch DB and applied cleanly in production; all user data intact.
+
+No other changes. Version bump only so the release tag matches the deployed images exactly.
+
+**Full Changelog**: https://github.com/slimatic/zakapp/compare/v0.16.0...v0.16.1
+
 ## [0.16.0] - 2026-09-12 — Moon Phase Release
 
 User-facing summary: **Push notifications for Zakat due reminders. App now speaks Arabic (with full right-to-left support) and lays the groundwork for 7 more languages. Broken links show a friendly 404 instead of a blank page. Local installs without sync no longer throw errors. Security dependencies fully clean.**

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "private": true,
   "dependencies": {
     "@headlessui/react": "^2.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zakapp",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "A user-friendly, self-hosted Zakat application with modern UI",
   "main": "server/index.js",
   "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zakapp-server",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "zakapp backend server",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Patch release so the v0.16.x tag matches what is actually deployed.

- Bump 0.16.0 → 0.16.1 (root/client/server)
- CHANGELOG entry documenting PR #386 (additive PushSubscription migration caught during the v0.16.0 production deploy verification)
- No functional changes; prod already runs this code (post-#386 :latest image)

Follow-up to #313 / PR #386