### PR TITLE
ops: backup rotation — keep only the latest backup set

### DIFF
--- a/scripts/ops/backup-before-upgrade.sh
+++ b/scripts/ops/backup-before-upgrade.sh
@@ -42,4 +42,14 @@ fi
 
 echo "✅ Backups written to $BACKUP_DIR:"
 ls -lh "$BACKUP_DIR" | grep "$STAMP"
+# 5. Rotation — keep ONLY the latest backup set (rollback anchor).
+# Policy (Slim, 2026-09-12): one recent backup is enough for rollback; older
+# sets are pruned so $BACKUP_DIR never grows unbounded. Files written by THIS
+# run are kept; zakapp-* files from previous runs are removed.
+keep_n=3  # newest config + sqlite + couchdb from this run
+ls -t "$BACKUP_DIR"/zakapp-* 2>/dev/null | tail -n +$((keep_n + 1)) | while read -r f; do
+    rm -f "$f"
+    echo "   pruned old backup: $(basename "$f")"
+done
+
 echo "Deploy may proceed."


### PR DESCRIPTION
Per Slim's policy: 'we only need the last backup for just a rollback.'

- `scripts/ops/backup-before-upgrade.sh` prunes older `zakapp-*` archives after a successful backup, keeping only the newest config/DB set as the rollback anchor
- Applied server-side already: `re-init-umbrel-v2.sh` (watchdog) now rotates; `~/backups` went from 580 files / 206MB → newest pair only
- The old `zakapp-upgrades/app.zakapp.org-v091-*.tar.gz` archive left untouched (pre-policy history)