### PR TITLE
fix: replace hardcoded USD figures with live nisab data

### DIFF
--- a/client/src/components/FinalizationModal.tsx
+++ b/client/src/components/FinalizationModal.tsx
@@ -137,7 +137,14 @@ export const FinalizationModal: React.FC<FinalizationModalProps> = ({
 
   // Format currency
   const formatCurrency = (amount: number): string => {
-    if (isNaN(amount)) return '$0.00';
+    if (isNaN(amount)) {
+      return new Intl.NumberFormat('en-US', {
+        style: 'currency',
+        currency: record.currency || 'USD',
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 2,
+      }).format(0);
+    }
     return new Intl.NumberFormat('en-US', {
       style: 'currency',
       currency: record.currency || 'USD',

--- a/client/src/components/assets/AssetDetails.tsx
+++ b/client/src/components/assets/AssetDetails.tsx
@@ -350,7 +350,7 @@ export const AssetDetails: React.FC = () => {
             <div className="text-sm text-gray-700">
               <p className="font-medium mb-1">🚫 Asset Excluded from Calculations</p>
               <p>
-                Calculated Zakat: $0.00
+                Calculated Zakat: {formatCurrency(0, safeAsset.currency)}
               </p>
               {safeAsset.subCategory === 'jewelry' && (
                 <p className="mt-2 text-xs text-gray-500 italic">

--- a/client/src/components/history/History.tsx
+++ b/client/src/components/history/History.tsx
@@ -122,7 +122,7 @@ export const History: React.FC = () => {
                   <dd className="text-lg font-medium text-gray-900">
                     {snapshots.length > 0 
                       ? formatCurrency(snapshots.reduce((sum, s) => sum + s.zakatOwed, 0))
-                      : '$0.00'
+                      : formatCurrency(0)
                     }
                   </dd>
                 </dl>

--- a/client/src/components/zakat/MethodologySelector.tsx
+++ b/client/src/components/zakat/MethodologySelector.tsx
@@ -268,8 +268,8 @@ export const MethodologySelector: React.FC<MethodologySelectorProps> = ({
             <div>
               <p className="font-medium text-blue-900">What's the difference between gold and silver nisab?</p>
               <p className="text-blue-800 mt-1">
-                Gold nisab (85g) typically results in a higher threshold (~$5,500), while silver nisab (595g) 
-                is lower (~$400). The Hanafi school uses the lower threshold to maximize benefit to those in need.
+                Gold nisab (~87g) results in a higher threshold because gold is more valuable per gram, while silver nisab (~612g) 
+                is lower in monetary terms. The live thresholds in your currency are shown above. The Hanafi school uses the lower (silver) threshold to maximize benefit to those in need.
               </p>
             </div>
             

--- a/client/src/components/zakat/NisabExplainer.tsx
+++ b/client/src/components/zakat/NisabExplainer.tsx
@@ -15,37 +15,69 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
+import { apiService } from '../../services/api';
+import { formatCurrency } from '../../utils/formatters';
 
 /**
  * NisabExplainer Component - T026
  *
  * Explains nisab thresholds with visual graphics and Islamic references
  */
+interface LiveNisabData {
+  currency: string;
+  goldPrice: { pricePerGram: number; nisabGrams: number; nisabValue: number };
+  silverPrice: { pricePerGram: number; nisabGrams: number; nisabValue: number };
+}
+
 const NisabExplainer: React.FC = () => {
   const [selectedMetal, setSelectedMetal] = useState<'gold' | 'silver'>('gold');
+  const [live, setLive] = useState<LiveNisabData | null>(null);
+  const [loadFailed, setLoadFailed] = useState(false);
 
-  // Current nisab values (approximate as of 2024 - these would be calculated dynamically)
-  const nisabValues = {
-    gold: {
-      name: 'Gold Nisab',
-      threshold: 87.48, // grams
-      value: 7500, // USD equivalent
-      description: 'Based on 87.48 grams of pure gold'
-    },
-    silver: {
-      name: 'Silver Nisab',
-      threshold: 612.36, // grams
-      value: 750, // USD equivalent
-      description: 'Based on 612.36 grams of pure silver'
-    }
-  };
+  useEffect(() => {
+    let cancelled = false;
+    apiService
+      .getNisab()
+      .then((res) => {
+        if (!cancelled && res?.data?.goldPrice && res?.data?.silverPrice) {
+          setLive(res.data as LiveNisabData);
+        } else if (!cancelled) {
+          setLoadFailed(true);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setLoadFailed(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
-  const currentNisab = nisabValues[selectedMetal];
+  // Fallback when the live endpoint is unavailable — no fake "current" figures.
+  const nisabValues = live
+    ? {
+        gold: {
+          name: 'Gold Nisab',
+          threshold: live.goldPrice.nisabGrams,
+          value: live.goldPrice.nisabValue,
+          description: `Based on ${live.goldPrice.nisabGrams.toFixed(2)} grams of pure gold`
+        },
+        silver: {
+          name: 'Silver Nisab',
+          threshold: live.silverPrice.nisabGrams,
+          value: live.silverPrice.nisabValue,
+          description: `Based on ${live.silverPrice.nisabGrams.toFixed(2)} grams of pure silver`
+        }
+      }
+    : null;
+
+  const currentNisab = nisabValues?.[selectedMetal];
+  const cur = (live?.currency ?? 'USD') as Parameters<typeof formatCurrency>[1];
 
   // Visual representation data
-  const goldBars = Math.ceil(currentNisab.threshold / 10); // Approximate 10g bars
-  const silverCoins = Math.ceil(currentNisab.threshold / 20); // Approximate 20g coins
+  const goldBars = currentNisab ? Math.ceil(currentNisab.threshold / 10) : 0; // Approximate 10g bars
+  const silverCoins = currentNisab ? Math.ceil(currentNisab.threshold / 20) : 0; // Approximate 20g coins
 
   return (
     <div className="space-y-6">
@@ -135,15 +167,15 @@ const NisabExplainer: React.FC = () => {
         {/* Threshold Display */}
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
           <div className="text-center p-4 bg-gray-50 rounded-lg">
-            <div className="text-2xl font-bold text-gray-900">{currentNisab.threshold.toFixed(2)}</div>
+            <div className="text-2xl font-bold text-gray-900">{currentNisab ? currentNisab.threshold.toFixed(2) : '—'}</div>
             <div className="text-sm text-gray-600">Grams of {selectedMetal}</div>
           </div>
           <div className="text-center p-4 bg-green-50 rounded-lg">
-            <div className="text-2xl font-bold text-green-600">${currentNisab.value.toLocaleString()}</div>
+            <div className="text-2xl font-bold text-green-600">{currentNisab ? formatCurrency(currentNisab.value, cur) : '—'}</div>
             <div className="text-sm text-gray-600">USD Equivalent</div>
           </div>
           <div className="text-center p-4 bg-blue-50 rounded-lg">
-            <div className="text-2xl font-bold text-blue-600">{currentNisab.threshold * 2.5 / 1000}kg</div>
+            <div className="text-2xl font-bold text-blue-600">{currentNisab ? `${(currentNisab.threshold * 2.5 / 1000).toFixed(2)}kg` : '—'}</div>
             <div className="text-sm text-gray-600">Weight</div>
           </div>
         </div>
@@ -154,7 +186,7 @@ const NisabExplainer: React.FC = () => {
           <div className="bg-gray-50 p-6 rounded-lg">
             <div className="text-center mb-4">
               <p className="text-gray-600">
-                {currentNisab.description} (≈ ${currentNisab.value.toLocaleString()} USD)
+                {currentNisab ? `${currentNisab.description} (≈ ${formatCurrency(currentNisab.value, cur)})` : 'Live nisab figures unavailable right now.'}
               </p>
             </div>
 
@@ -188,22 +220,22 @@ const NisabExplainer: React.FC = () => {
             <h4 className="font-medium text-gray-900">Gold Price</h4>
             <div className="flex items-center justify-between p-3 bg-yellow-50 rounded-lg">
               <span className="text-yellow-800">Per Gram</span>
-              <span className="font-bold text-yellow-900">$85.60</span>
+              <span className="font-bold text-yellow-900">{live ? formatCurrency(live.goldPrice.pricePerGram, cur) : '—'}</span>
             </div>
             <div className="flex items-center justify-between p-3 bg-yellow-50 rounded-lg">
               <span className="text-yellow-800">Per Ounce</span>
-              <span className="font-bold text-yellow-900">$2,662</span>
+              <span className="font-bold text-yellow-900">{live ? formatCurrency(live.goldPrice.pricePerGram * 31.1035, cur) : '—'}</span>
             </div>
           </div>
           <div className="space-y-3">
             <h4 className="font-medium text-gray-900">Silver Price</h4>
             <div className="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
               <span className="text-gray-800">Per Gram</span>
-              <span className="font-bold text-gray-900">$1.23</span>
+              <span className="font-bold text-gray-900">{live ? formatCurrency(live.silverPrice.pricePerGram, cur) : '—'}</span>
             </div>
             <div className="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
               <span className="text-gray-800">Per Ounce</span>
-              <span className="font-bold text-gray-900">$38.25</span>
+              <span className="font-bold text-gray-900">{live ? formatCurrency(live.silverPrice.pricePerGram * 31.1035, cur) : '—'}</span>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Found during the zakapp.org / USD-reference audit.

## Root cause
The **education/learn section** (Nisab Explainer → "Current Market Values") hardcoded stale prices — **$85.60/gold gram and $1.23/silver gram under a "Current Market Values" heading** (live: $139.81 / $2.07) — plus $7,500/$750 nisab equivalents. MethodologySelector's FAQ had stale ~$5,500/~$400 nisab figures.

## Fix
- **NisabExplainer** now fetches the public nisab endpoint (`GET /api/zakat/nisab?currency=`) with the user's currency and renders live gold/silver prices (per gram + per ounce) and nisab thresholds via the shared locale-aware `formatCurrency`. When the endpoint is unavailable it shows an honest `—` placeholder — never fake "current" figures.
- **MethodologySelector FAQ** reworded to direction-correct relative phrasing (no stale numbers), pointing users at the live thresholds shown above.
- **Fallbacks currency-aware**: AssetDetails excluded-asset line, FinalizationModal + History NaN/empty fallbacks no longer hardcode `$0.00`.

Education example narratives (Ahmed's $800 scenario, ZakatGuide $25,000 example) are clearly-labeled illustrative prose and stay for now — follow-up issue tracks currency-aware i18n for them.

## Gates
tsc clean · 546/546 tests · build green