### PR TITLE
fix: label methodology examples as illustrative figures

### DIFF
--- a/client/src/components/zakat/MethodologySelector.tsx
+++ b/client/src/components/zakat/MethodologySelector.tsx
@@ -182,6 +182,10 @@ export const MethodologySelector: React.FC<MethodologySelectorProps> = ({
                     {/* Practical Example */}
                     <section className="bg-gray-50 rounded-lg p-4">
                       <h3 className="text-lg font-semibold text-gray-900 mb-2">Practical Example</h3>
+                      <p className="text-xs text-gray-500 italic mb-3">
+                        Illustrative figures only — the nisab amounts shown here are hypothetical.
+                        Your live nisab thresholds (in your currency) are shown in the cards above.
+                      </p>
                       <div className="space-y-3">
                         <div>
                           <p className="font-medium text-gray-700">Scenario:</p>


### PR DESCRIPTION
Follow-up to PR #389 from the USD-reference audit.

The Zakat calculator methodology cards show worked examples with hypothetical \$ nisab figures (\,500/\00) directly below live thresholds — reads as current data. Added an explicit 'Illustrative figures only' note directing users to the live thresholds shown above.

tsc clean.